### PR TITLE
Extend OpenTelemetry Tracer with resource detectors

### DIFF
--- a/api/envoy/config/trace/v3/opentelemetry.proto
+++ b/api/envoy/config/trace/v3/opentelemetry.proto
@@ -4,7 +4,10 @@ package envoy.config.trace.v3;
 
 import "envoy/config/core/v3/grpc_service.proto";
 
+import "google/protobuf/any.proto";
+
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "OpentelemetryProto";
@@ -13,6 +16,16 @@ option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: OpenTelemetry tracer]
+
+message ResourceDetector {
+  // The name of the resource detector to instantiate.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Resource detector specific configuration which depends on the detector being
+  // instantiated. See the supported detectors for further documentation.
+  // Not required for detectors that don't need a config. E.g., Environment variable Detector
+  google.protobuf.Any typed_config = 2;
+}
 
 // Configuration for the OpenTelemetry tracer.
 //  [#extension: envoy.tracers.opentelemetry]
@@ -25,4 +38,8 @@ message OpenTelemetryConfig {
   // The name for the service. This will be populated in the ResourceSpan Resource attributes.
   // If it is not provided, it will default to "unknown_service:envoy".
   string service_name = 2;
+
+  // An ordered list of resource detectors
+  // [#extension-category: envoy.tracers.opentelemetry.resource_detectors]
+  repeated ResourceDetector resource_detectors = 3;
 }

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -255,6 +255,12 @@ EXTENSIONS = {
     "envoy.tracers.opentelemetry":                      "//source/extensions/tracers/opentelemetry:config",
 
     #
+    # OpenTelemetry Resource Detectors
+    #
+
+    "envoy.tracers.opentelemetry.resource_detectors.environment":         "//source/extensions/tracers/opentelemetry/resource_detectors/environment:config",
+
+    #
     # Transport sockets
     #
 

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1630,3 +1630,8 @@ envoy.config_mux.sotw_grpc_mux_factory:
   - envoy.config_mux
   security_posture: unknown
   status: stable
+envoy.tracers.opentelemetry.resource_detectors.environment:
+  categories:
+  - envoy.tracers.opentelemetry.resource_detectors
+  security_posture: unknown
+  status: wip

--- a/source/extensions/tracers/opentelemetry/BUILD
+++ b/source/extensions/tracers/opentelemetry/BUILD
@@ -41,6 +41,7 @@ envoy_cc_library(
         "//source/common/config:utility_lib",
         "//source/common/tracing:http_tracer_lib",
         "//source/extensions/tracers/common:factory_base_lib",
+        "//source/extensions/tracers/opentelemetry/resource_detectors:resource_detector_lib",
         "@envoy_api//envoy/config/trace/v3:pkg_cc_proto",
         "@opentelemetry_proto//:trace_cc_proto",
     ],

--- a/source/extensions/tracers/opentelemetry/config.cc
+++ b/source/extensions/tracers/opentelemetry/config.cc
@@ -6,6 +6,7 @@
 
 #include "source/common/common/logger.h"
 #include "source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h"
+#include "source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -18,7 +19,9 @@ OpenTelemetryTracerFactory::OpenTelemetryTracerFactory()
 Tracing::DriverSharedPtr OpenTelemetryTracerFactory::createTracerDriverTyped(
     const envoy::config::trace::v3::OpenTelemetryConfig& proto_config,
     Server::Configuration::TracerFactoryContext& context) {
-  return std::make_shared<Driver>(proto_config, context);
+
+  ResourceProviderImpl resource_provider;
+  return std::make_shared<Driver>(proto_config, context, resource_provider);
 }
 
 /**

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h
@@ -9,6 +9,7 @@
 #include "source/common/singleton/const_singleton.h"
 #include "source/extensions/tracers/common/factory_base.h"
 #include "source/extensions/tracers/opentelemetry/grpc_trace_exporter.h"
+#include "source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h"
 #include "source/extensions/tracers/opentelemetry/tracer.h"
 
 namespace Envoy {
@@ -30,7 +31,8 @@ using OpenTelemetryConstants = ConstSingleton<OpenTelemetryConstantValues>;
 class Driver : Logger::Loggable<Logger::Id::tracing>, public Tracing::Driver {
 public:
   Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetry_config,
-         Server::Configuration::TracerFactoryContext& context);
+         Server::Configuration::TracerFactoryContext& context,
+         const ResourceProvider& resource_provider);
 
   // Tracing::Driver
   Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,

--- a/source/extensions/tracers/opentelemetry/resource_detectors/BUILD
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/BUILD
@@ -1,0 +1,27 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_library(
+    name = "resource_detector_lib",
+    srcs = [
+        "resource_provider.cc",
+    ],
+    hdrs = [
+        "resource_detector.h",
+        "resource_provider.h",
+    ],
+    deps = [
+        "//envoy/config:typed_config_interface",
+        "//envoy/server:tracer_config_interface",
+        "//source/common/common:logger_lib",
+        "//source/common/config:utility_lib",
+        "@envoy_api//envoy/config/trace/v3:pkg_cc_proto",
+    ],
+)

--- a/source/extensions/tracers/opentelemetry/resource_detectors/environment/BUILD
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/environment/BUILD
@@ -1,0 +1,31 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":resource_detector_environment_lib",
+        "//envoy/registry",
+        "//source/common/config:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "resource_detector_environment_lib",
+    srcs = ["environment_resource_detector.cc"],
+    hdrs = ["environment_resource_detector.h"],
+    deps = [
+        "//source/common/config:datasource_lib",
+        "//source/extensions/tracers/opentelemetry/resource_detectors:resource_detector_lib",
+    ],
+)

--- a/source/extensions/tracers/opentelemetry/resource_detectors/environment/config.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/environment/config.cc
@@ -1,0 +1,25 @@
+#include "config.h"
+
+#include "source/common/config/utility.h"
+
+#include "environment_resource_detector.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+ResourceDetectorPtr EnvironmentResourceDetectorFactory::createResourceDetector(
+    Server::Configuration::TracerFactoryContext& context) {
+  return std::make_shared<EnvironmentResourceDetector>(context);
+}
+
+/**
+ * Static registration for the Env resource detector factory. @see RegisterFactory.
+ */
+REGISTER_FACTORY(EnvironmentResourceDetectorFactory, ResourceDetectorFactory);
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/resource_detectors/environment/config.h
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/environment/config.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+
+#include "source/extensions/tracers/opentelemetry/resource_detectors/resource_detector.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * Config registration for the Environment resource detector. @see ResourceDetectorFactory.
+ */
+class EnvironmentResourceDetectorFactory : public ResourceDetectorFactory {
+public:
+  /**
+   * @brief Create a Resource Detector that reads from the OTEL_RESOURCE_ATTRIBUTES
+   * environment variable.
+   *
+   * @param context
+   * @return ResourceDetectorPtr
+   */
+  ResourceDetectorPtr
+  createResourceDetector(Server::Configuration::TracerFactoryContext& context) override;
+
+  std::string name() const override {
+    return "envoy.tracers.opentelemetry.resource_detectors.environment";
+  }
+};
+
+DECLARE_FACTORY(EnvironmentResourceDetectorFactory);
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/resource_detectors/environment/environment_resource_detector.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/environment/environment_resource_detector.cc
@@ -1,0 +1,56 @@
+#include "environment_resource_detector.h"
+
+#include <sstream>
+#include <string>
+
+#include "source/common/config/datasource.h"
+#include "source/extensions/tracers/opentelemetry/resource_detectors/resource_detector.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+constexpr absl::string_view kOtelResourceAttributesEnv = "OTEL_RESOURCE_ATTRIBUTES";
+
+/**
+ * @brief Detects a resource from the OTEL_RESOURCE_ATTRIBUTES environment variable
+ * Based on the OTel C++ SDK:
+ * https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.11.0/sdk/src/resource/resource_detector.cc
+ *
+ * @return Resource A resource with the attributes from the OTEL_RESOURCE_ATTRIBUTES environment
+ * variable.
+ */
+Resource EnvironmentResourceDetector::detect() {
+  envoy::config::core::v3::DataSource ds;
+  ds.set_environment_variable(kOtelResourceAttributesEnv);
+
+  Resource resource;
+  resource.schemaUrl = "";
+
+  TRY_NEEDS_AUDIT {
+    auto attributes_str = Config::DataSource::read(ds, true, context_.serverFactoryContext().api());
+    if (attributes_str.empty()) {
+      return resource;
+    }
+
+    std::istringstream iss(attributes_str);
+    std::string token;
+    while (std::getline(iss, token, ',')) {
+      size_t pos = token.find('=');
+      std::string key = token.substr(0, pos);
+      std::string value = token.substr(pos + 1);
+      resource.attributes[key] = value;
+    }
+  }
+  END_TRY catch (const EnvoyException& e) {
+    ENVOY_LOG(error, "Failed to read resource attributes: {}.", e.what());
+  }
+
+  return resource;
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/resource_detectors/environment/environment_resource_detector.h
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/environment/environment_resource_detector.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "envoy/server/factory_context.h"
+
+#include "source/common/common/logger.h"
+#include "source/extensions/tracers/opentelemetry/resource_detectors/resource_detector.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * @brief A resource detector that extracts attributes from the OTEL_RESOURCE_ATTRIBUTES environment
+ * variable.
+ * @see
+ * https://github.com/open-telemetry/opentelemetry-specification/blob/v1.24.0/specification/resource/sdk.md#detecting-resource-information-from-the-environment
+ *
+ */
+class EnvironmentResourceDetector : public ResourceDetector, Logger::Loggable<Logger::Id::tracing> {
+public:
+  EnvironmentResourceDetector(Server::Configuration::TracerFactoryContext& context)
+      : context_(context) {}
+  Resource detect() override;
+
+private:
+  Server::Configuration::TracerFactoryContext&
+      context_; // TODO, is keeping a reference ok (ownership)?
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_detector.h
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_detector.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "envoy/config/typed_config.h"
+#include "envoy/server/tracer_config.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+using ResourceAttributes = std::map<std::string, std::string>;
+
+class Resource {
+public:
+  std::string schemaUrl{""};
+  ResourceAttributes attributes{};
+
+  virtual ~Resource() = default;
+};
+
+/**
+ * @brief The base type for all resource detectors
+ *
+ */
+class ResourceDetector {
+public:
+  virtual ~ResourceDetector() = default;
+
+  /**
+   * @brief Load attributes and returns a Resource object
+   * populated with them and a possible SchemaUrl.
+   * @return Resource
+   */
+  virtual Resource detect() = 0;
+};
+
+using ResourceDetectorPtr = std::shared_ptr<ResourceDetector>;
+
+/*
+ * A factory for creating resource detectors that have configuration.
+ */
+class ResourceDetectorTypedFactory : public Envoy::Config::TypedFactory {
+public:
+  ~ResourceDetectorTypedFactory() override = default;
+
+  /**
+   * @brief Creates a resource detector based on the configuration type provided.
+   *
+   * @param message The resource detector configuration.
+   * @param context The tracer factory context.
+   * @return ResourceDetectorPtr A resource detector based on the configuration type provided.
+   */
+  virtual ResourceDetectorPtr
+  createTypedResourceDetector(const Protobuf::Message& message,
+                              Server::Configuration::TracerFactoryContext& context) PURE;
+
+  std::string category() const override { return "envoy.tracers.opentelemetry.resource_detectors"; }
+};
+
+using ResourceDetectorTypedFactoryPtr = std::unique_ptr<ResourceDetectorTypedFactory>;
+
+/*
+ * A factory for creating resource detectors without configuration.
+ */
+class ResourceDetectorFactory : public Envoy::Config::UntypedFactory {
+public:
+  ~ResourceDetectorFactory() override = default;
+
+  /**
+   * @brief Creates a resource detector that does not have a configuration.
+   *
+   * @param context The tracer factory context.
+   * @return ResourceDetectorPtr A resource detector based on the provided name.
+   */
+  virtual ResourceDetectorPtr
+  createResourceDetector(Server::Configuration::TracerFactoryContext& context) PURE;
+
+  std::string category() const override { return "envoy.tracers.opentelemetry.resource_detectors"; }
+};
+
+using ResourceDetectorFactoryPtr = std::unique_ptr<ResourceDetectorFactory>;
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.cc
@@ -1,0 +1,121 @@
+#include "resource_provider.h"
+
+#include <string>
+
+#include "source/common/common/logger.h"
+#include "source/common/config/utility.h"
+
+#include "resource_detector.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+namespace {
+bool isEmptyResource(const Resource& resource) { return resource.attributes.empty(); }
+
+Resource createInitialResource(std::string service_name) {
+  Resource resource{};
+
+  // Creates initial resource with the static service.name attribute.
+  if (service_name.empty()) {
+    service_name = std::string{kDefaultServiceName};
+  }
+  resource.attributes[std::string(kServiceNameKey.data(), kServiceNameKey.size())] = service_name;
+  return resource;
+}
+
+/**
+ * @brief Calculates the new schema url when merging two resources.
+ * This function implements the algorightm as defined in the OpenTelemetry Resource SDK
+ * specification. @see
+ * https://github.com/open-telemetry/opentelemetry-specification/blob/v1.24.0/specification/resource/sdk.md#merge
+ *
+ * @param old_schema_url The old resource's schema URL.
+ * @param updating_schema_url The updating resource's schema URL.
+ * @return std::string The calculated schema URL.
+ */
+std::string mergeSchemaUrl(const std::string& old_schema_url,
+                           const std::string& updating_schema_url) {
+  if (old_schema_url.empty()) {
+    return updating_schema_url;
+  }
+  if (updating_schema_url.empty()) {
+    return old_schema_url;
+  }
+  if (old_schema_url == updating_schema_url) {
+    return old_schema_url;
+  }
+  // The OTel spec leaves this case (when both have value but are different) unspecified.
+  ENVOY_LOG_MISC(info, "Resource schemaUrl conflict. Fall-back to old schema url: {}",
+                 old_schema_url);
+  return old_schema_url;
+}
+
+/**
+ * @brief Updates an old resource with a new one. This function implements
+ * the Merge operation defined in the OpenTelemetry Resource SDK specification.
+ * @see
+ * https://github.com/open-telemetry/opentelemetry-specification/blob/v1.24.0/specification/resource/sdk.md#merge
+ *
+ * @param old_resource The old resource.
+ * @param updating_resource The new resource.
+ */
+void mergeResource(Resource& old_resource, const Resource& updating_resource) {
+  if (isEmptyResource(updating_resource)) {
+    return;
+  }
+  for (auto const& attr : updating_resource.attributes) {
+    old_resource.attributes.insert_or_assign(attr.first, attr.second);
+  }
+  old_resource.schemaUrl = mergeSchemaUrl(old_resource.schemaUrl, updating_resource.schemaUrl);
+}
+} // namespace
+
+const Resource ResourceProviderImpl::getResource(
+    const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetry_config,
+    Server::Configuration::TracerFactoryContext& context) const {
+
+  Resource resource = createInitialResource(opentelemetry_config.service_name());
+
+  auto detectors_configs = opentelemetry_config.resource_detectors();
+  for (const auto& detector_config : detectors_configs) {
+    ResourceDetectorPtr detector;
+    if (detector_config.has_typed_config()) {
+      auto* factory =
+          Envoy::Config::Utility::getFactory<ResourceDetectorTypedFactory>(detector_config);
+
+      if (!factory) {
+        throw EnvoyException(
+            fmt::format("Resource detector factory not found: '{}'", detector_config.name()));
+      }
+
+      detector = factory->createTypedResourceDetector(detector_config.typed_config(), context);
+    } else {
+      auto* factory =
+          Envoy::Config::Utility::getFactoryByName<ResourceDetectorFactory>(detector_config.name());
+
+      if (!factory) {
+        throw EnvoyException(
+            fmt::format("Resource detector factory not found: '{}'", detector_config.name()));
+      }
+
+      detector = factory->createResourceDetector(context);
+    }
+
+    if (!detector) {
+      throw EnvoyException(
+          fmt::format("Resource detector could not be created: '{}'", detector_config.name()));
+    }
+
+    Resource detected_resource = detector->detect();
+    mergeResource(resource, detected_resource);
+  }
+  return resource;
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "envoy/config/trace/v3/opentelemetry.pb.h"
+
+#include "resource_detector.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+constexpr absl::string_view kServiceNameKey = "service.name";
+constexpr absl::string_view kDefaultServiceName = "unknown_service:envoy";
+
+class ResourceProvider : public Logger::Loggable<Logger::Id::tracing> {
+public:
+  virtual ~ResourceProvider() = default;
+
+  /**
+   * @brief Iterates through all loaded resource detectors and merge all the returned
+   * resources into one. Resource merging is done according to the OpenTelemetry
+   * resource SDK specification. @see
+   * https://github.com/open-telemetry/opentelemetry-specification/blob/v1.24.0/specification/resource/sdk.md#merge.
+   *
+   * @param opentelemetry_config The opentelemetry configuration, which contains the configured
+   * resource detectors.
+   * @param context The tracer factory context.
+   * @return Resource const The merged resource.
+   */
+  virtual Resource const
+  getResource(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetry_config,
+              Server::Configuration::TracerFactoryContext& context) const = 0;
+};
+
+class ResourceProviderImpl : public ResourceProvider {
+public:
+  Resource const
+  getResource(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetry_config,
+              Server::Configuration::TracerFactoryContext& context) const override;
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -19,8 +19,6 @@ namespace OpenTelemetry {
 constexpr absl::string_view kTraceParent = "traceparent";
 constexpr absl::string_view kTraceState = "tracestate";
 constexpr absl::string_view kDefaultVersion = "00";
-constexpr absl::string_view kServiceNameKey = "service.name";
-constexpr absl::string_view kDefaultServiceName = "unknown_service:envoy";
 
 using opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
 
@@ -94,12 +92,9 @@ void Span::setTag(absl::string_view name, absl::string_view value) {
 Tracer::Tracer(OpenTelemetryGrpcTraceExporterPtr exporter, Envoy::TimeSource& time_source,
                Random::RandomGenerator& random, Runtime::Loader& runtime,
                Event::Dispatcher& dispatcher, OpenTelemetryTracerStats tracing_stats,
-               const std::string& service_name)
+               const Resource& resource)
     : exporter_(std::move(exporter)), time_source_(time_source), random_(random), runtime_(runtime),
-      tracing_stats_(tracing_stats), service_name_(service_name) {
-  if (service_name.empty()) {
-    service_name_ = std::string{kDefaultServiceName};
-  }
+      tracing_stats_(tracing_stats), resource_(resource) {
   flush_timer_ = dispatcher.createTimer([this]() -> void {
     tracing_stats_.timer_flushed_.inc();
     flushSpans();
@@ -118,14 +113,20 @@ void Tracer::flushSpans() {
   ExportTraceServiceRequest request;
   // A request consists of ResourceSpans.
   ::opentelemetry::proto::trace::v1::ResourceSpans* resource_span = request.add_resource_spans();
-  opentelemetry::proto::common::v1::KeyValue key_value =
-      opentelemetry::proto::common::v1::KeyValue();
-  opentelemetry::proto::common::v1::AnyValue value_proto =
-      opentelemetry::proto::common::v1::AnyValue();
-  value_proto.set_string_value(std::string{service_name_});
-  key_value.set_key(std::string{kServiceNameKey});
-  *key_value.mutable_value() = value_proto;
-  (*resource_span->mutable_resource()->add_attributes()) = key_value;
+  resource_span->set_schema_url(resource_.schemaUrl);
+
+  // add resource attributes
+  for (auto const& att : resource_.attributes) {
+    opentelemetry::proto::common::v1::KeyValue key_value =
+        opentelemetry::proto::common::v1::KeyValue();
+    opentelemetry::proto::common::v1::AnyValue value_proto =
+        opentelemetry::proto::common::v1::AnyValue();
+    value_proto.set_string_value(std::string{att.second});
+    key_value.set_key(std::string{att.first});
+    *key_value.mutable_value() = value_proto;
+    (*resource_span->mutable_resource()->add_attributes()) = key_value;
+  }
+
   ::opentelemetry::proto::trace::v1::ScopeSpans* scope_span = resource_span->add_scope_spans();
   for (const auto& pending_span : span_buffer_) {
     (*scope_span->add_spans()) = pending_span;

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -11,6 +11,7 @@
 #include "source/common/common/logger.h"
 #include "source/extensions/tracers/common/factory_base.h"
 #include "source/extensions/tracers/opentelemetry/grpc_trace_exporter.h"
+#include "source/extensions/tracers/opentelemetry/resource_detectors/resource_detector.h"
 
 #include "absl/strings/escaping.h"
 #include "span_context.h"
@@ -35,7 +36,7 @@ class Tracer : Logger::Loggable<Logger::Id::tracing> {
 public:
   Tracer(OpenTelemetryGrpcTraceExporterPtr exporter, Envoy::TimeSource& time_source,
          Random::RandomGenerator& random, Runtime::Loader& runtime, Event::Dispatcher& dispatcher,
-         OpenTelemetryTracerStats tracing_stats, const std::string& service_name);
+         OpenTelemetryTracerStats tracing_stats, const Resource& resource);
 
   void sendSpan(::opentelemetry::proto::trace::v1::Span& span);
 
@@ -62,7 +63,7 @@ private:
   Runtime::Loader& runtime_;
   Event::TimerPtr flush_timer_;
   OpenTelemetryTracerStats tracing_stats_;
-  std::string service_name_;
+  const Resource resource_;
 };
 
 /**

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -27,6 +27,14 @@ using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
 
+class MockResourceProvider : public ResourceProvider {
+public:
+  MOCK_METHOD(const Resource, getResource,
+              (const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetry_config,
+               Server::Configuration::TracerFactoryContext& context),
+              (const));
+};
+
 class OpenTelemetryDriverTest : public testing::Test {
 public:
   OpenTelemetryDriverTest() = default;
@@ -44,7 +52,13 @@ public:
         .WillByDefault(Return(ByMove(std::move(mock_client_factory))));
     ON_CALL(factory_context, scope()).WillByDefault(ReturnRef(scope_));
 
-    driver_ = std::make_unique<Driver>(opentelemetry_config, context_);
+    Resource resource;
+    resource.attributes.insert(std::pair<std::string, std::string>("key1", "val1"));
+
+    auto mock_resource_provider = NiceMock<MockResourceProvider>();
+    EXPECT_CALL(mock_resource_provider, getResource(_, _)).WillRepeatedly(Return(resource));
+
+    driver_ = std::make_unique<Driver>(opentelemetry_config, context_, mock_resource_provider);
   }
 
   void setupValidDriver() {
@@ -135,6 +149,9 @@ resource_spans:
       key: "service.name"
       value:
         string_value: "unknown_service:envoy"
+      key: "key1"
+      value:
+        string_value: "val1"
   scope_spans:
     spans:
       trace_id: "AAA"
@@ -377,6 +394,9 @@ resource_spans:
       key: "service.name"
       value:
         string_value: "unknown_service:envoy"
+      key: "key1"
+      value:
+        string_value: "val1"
   scope_spans:
     spans:
       trace_id: "AAA"
@@ -483,6 +503,9 @@ resource_spans:
       key: "service.name"
       value:
         string_value: "test-service-name"
+      key: "key1"
+      value:
+        string_value: "val1"
   scope_spans:
     spans:
       trace_id: "AAA"

--- a/test/extensions/tracers/opentelemetry/resource_detectors/BUILD
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/BUILD
@@ -1,0 +1,21 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test(
+    name = "resource_provider_test",
+    srcs = ["resource_provider_test.cc"],
+    deps = [
+        "//envoy/registry",
+        "//source/extensions/tracers/opentelemetry/resource_detectors:resource_detector_lib",
+        "//test/mocks/server:tracer_factory_context_mocks",
+        "//test/test_common:registry_lib",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/extensions/tracers/opentelemetry/resource_detectors/environment/BUILD
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/environment/BUILD
@@ -1,0 +1,36 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    extension_names = ["envoy.tracers.opentelemetry.resource_detectors.environment"],
+    deps = [
+        "//envoy/registry",
+        "//source/extensions/tracers/opentelemetry/resource_detectors/environment:config",
+        "//source/extensions/tracers/opentelemetry/resource_detectors/environment:resource_detector_environment_lib",
+        "//test/mocks/server:tracer_factory_context_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "environment_resource_detector_test",
+    srcs = ["environment_resource_detector_test.cc"],
+    extension_names = ["envoy.tracers.opentelemetry.resource_detectors.environment"],
+    deps = [
+        "//source/extensions/tracers/opentelemetry/resource_detectors/environment:resource_detector_environment_lib",
+        "//test/mocks/server:tracer_factory_context_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/extensions/tracers/opentelemetry/resource_detectors/environment/config_test.cc
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/environment/config_test.cc
@@ -1,0 +1,27 @@
+#include "envoy/registry/registry.h"
+
+#include "source/extensions/tracers/opentelemetry/resource_detectors/environment/config.h"
+
+#include "test/mocks/server/tracer_factory_context.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+TEST(EnvironmentResourceDetectorFactoryTest, Basic) {
+  auto* factory = Registry::FactoryRegistry<ResourceDetectorFactory>::getFactory(
+      "envoy.tracers.opentelemetry.resource_detectors.environment");
+  ASSERT_NE(factory, nullptr);
+
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  EXPECT_NE(factory->createResourceDetector(context), nullptr);
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/resource_detectors/environment/environment_resource_detector_test.cc
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/environment/environment_resource_detector_test.cc
@@ -1,0 +1,75 @@
+#include <string>
+
+#include "envoy/registry/registry.h"
+
+#include "source/extensions/tracers/opentelemetry/resource_detectors/environment/environment_resource_detector.h"
+
+#include "test/mocks/server/tracer_factory_context.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::ReturnRef;
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+const std::string kOtelResourceAttributesEnv = "OTEL_RESOURCE_ATTRIBUTES";
+
+TEST(EnvironmentResourceDetectorTest, Detection) {
+  // OTEL_RESOURCE_ATTRIBUTES env variable not present
+  {
+    NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+    TestEnvironment::unsetEnvVar(kOtelResourceAttributesEnv);
+
+    auto detector = std::make_shared<EnvironmentResourceDetector>(context);
+    Resource resource = detector->detect();
+
+    EXPECT_EQ(resource.schemaUrl, "");
+    EXPECT_TRUE(resource.attributes.empty());
+  }
+  // OTEL_RESOURCE_ATTRIBUTES env variable present but empty
+  {
+    NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+    TestEnvironment::setEnvVar(kOtelResourceAttributesEnv, "", 1);
+
+    auto detector = std::make_shared<EnvironmentResourceDetector>(context);
+    Resource resource = detector->detect();
+
+    EXPECT_EQ(resource.schemaUrl, "");
+    EXPECT_TRUE(resource.attributes.empty());
+    TestEnvironment::unsetEnvVar(kOtelResourceAttributesEnv);
+  }
+  // // OTEL_RESOURCE_ATTRIBUTES env variable present and with attributes
+  {
+    NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+    TestEnvironment::setEnvVar(kOtelResourceAttributesEnv, "key1=val1,key2=val2", 1);
+    ResourceAttributes expected_attributes = {{"key1", "val1"}, {"key2", "val2"}};
+
+    Api::ApiPtr api = Api::createApiForTest();
+    EXPECT_CALL(context.server_factory_context_, api()).WillRepeatedly(ReturnRef(*api));
+
+    auto detector = std::make_shared<EnvironmentResourceDetector>(context);
+    Resource resource = detector->detect();
+
+    EXPECT_EQ(resource.schemaUrl, "");
+    EXPECT_EQ(2, resource.attributes.size());
+
+    for (auto& actual : resource.attributes) {
+      auto expected = expected_attributes.find(actual.first);
+
+      EXPECT_TRUE(expected != expected_attributes.end());
+      EXPECT_EQ(expected->second, actual.second);
+    }
+    TestEnvironment::unsetEnvVar(kOtelResourceAttributesEnv);
+  }
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc
@@ -1,0 +1,413 @@
+#include <string>
+
+#include "envoy/registry/registry.h"
+
+#include "source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h"
+
+#include "test/mocks/server/tracer_factory_context.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/registry.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::Return;
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+namespace {
+
+class SampleDetector : public ResourceDetector {
+public:
+  MOCK_METHOD(Resource, detect, ());
+};
+
+class UntypedDetectorFactory : public ResourceDetectorFactory {
+public:
+  MOCK_METHOD(ResourceDetectorPtr, createResourceDetector,
+              (Server::Configuration::TracerFactoryContext & context));
+
+  std::string name() const override {
+    return "envoy.tracers.opentelemetry.resource_detectors.untyped";
+  }
+};
+
+class TypedDetectorFactory : public ResourceDetectorTypedFactory {
+public:
+  MOCK_METHOD(ResourceDetectorPtr, createTypedResourceDetector,
+              (const Protobuf::Message& message,
+               Server::Configuration::TracerFactoryContext& context));
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<ProtobufWkt::Struct>();
+  }
+
+  std::string name() const override {
+    return "envoy.tracers.opentelemetry.resource_detectors.typed";
+  }
+};
+
+const std::string kOtelResourceAttributesEnv = "OTEL_RESOURCE_ATTRIBUTES";
+
+class ResourceProviderTest : public testing::Test {
+public:
+  ResourceProviderTest() {
+    resource_untyped_.attributes.insert(std::pair<std::string, std::string>("key1", "val1"));
+    resource_typed_.attributes.insert(std::pair<std::string, std::string>("key2", "val2"));
+  }
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context_;
+  Resource resource_untyped_;
+  Resource resource_typed_;
+};
+
+TEST_F(ResourceProviderTest, NoResourceDetectorsConfigured) {
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  ResourceProviderImpl resource_provider;
+  Resource resource = resource_provider.getResource(opentelemetry_config, context_);
+
+  EXPECT_EQ(resource.schemaUrl, "");
+
+  // Only the service name was added to the resource
+  EXPECT_EQ(1, resource.attributes.size());
+}
+
+TEST_F(ResourceProviderTest, ServiceNameNotProvided) {
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  ResourceProviderImpl resource_provider;
+  Resource resource = resource_provider.getResource(opentelemetry_config, context_);
+
+  EXPECT_EQ(resource.schemaUrl, "");
+
+  // service.name receives the unknown value when not configured
+  EXPECT_EQ(1, resource.attributes.size());
+  auto service_name = resource.attributes.find("service.name");
+  EXPECT_EQ("unknown_service:envoy", service_name->second);
+}
+
+TEST_F(ResourceProviderTest, MultipleResourceDetectorsConfigured) {
+  auto detector_untyped = std::make_shared<NiceMock<SampleDetector>>();
+  EXPECT_CALL(*detector_untyped, detect()).WillOnce(Return(resource_untyped_));
+
+  auto detector_typed = std::make_shared<NiceMock<SampleDetector>>();
+  EXPECT_CALL(*detector_typed, detect()).WillOnce(Return(resource_typed_));
+
+  UntypedDetectorFactory untyped_factory;
+  Registry::InjectFactory<ResourceDetectorFactory> untyped_factory_registration(untyped_factory);
+
+  TypedDetectorFactory typed_factory;
+  Registry::InjectFactory<ResourceDetectorTypedFactory> typed_factory_registration(typed_factory);
+
+  EXPECT_CALL(untyped_factory, createResourceDetector(_)).WillOnce(Return(detector_untyped));
+  EXPECT_CALL(typed_factory, createTypedResourceDetector(_, _)).WillOnce(Return(detector_typed));
+
+  // Expected merged attributes from all detectors
+  ResourceAttributes expected_attributes = {
+      {"service.name", "my-service"}, {"key1", "val1"}, {"key2", "val2"}};
+
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    resource_detectors:
+      - name: envoy.tracers.opentelemetry.resource_detectors.untyped
+      - name: envoy.tracers.opentelemetry.resource_detectors.typed
+        typed_config:
+            "@type": type.googleapis.com/google.protobuf.Struct
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  ResourceProviderImpl resource_provider;
+  Resource resource = resource_provider.getResource(opentelemetry_config, context_);
+
+  EXPECT_EQ(resource.schemaUrl, "");
+
+  // The resource should contain all 3 merged attributes
+  // service.name + 1 for each detector
+  EXPECT_EQ(3, resource.attributes.size());
+
+  for (auto& actual : resource.attributes) {
+    auto expected = expected_attributes.find(actual.first);
+
+    EXPECT_TRUE(expected != expected_attributes.end());
+    EXPECT_EQ(expected->second, actual.second);
+  }
+}
+
+TEST_F(ResourceProviderTest, UnknownResourceDetectors) {
+  // untyped resource detector
+  {
+    const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    resource_detectors:
+      - name: envoy.tracers.opentelemetry.resource_detectors.UnkownResourceDetector
+    )EOF";
+    envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+    TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+    ResourceProviderImpl resource_provider;
+    EXPECT_THROW_WITH_MESSAGE(
+        resource_provider.getResource(opentelemetry_config, context_), EnvoyException,
+        "Resource detector factory not found: "
+        "'envoy.tracers.opentelemetry.resource_detectors.UnkownResourceDetector'");
+  }
+  // typed resource detector
+  {
+    const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    resource_detectors:
+      - name: envoy.tracers.opentelemetry.resource_detectors.AnotherUnkownResourceDetector
+        typed_config:
+            "@type": type.googleapis.com/google.protobuf.Struct
+    )EOF";
+    envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+    TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+    ResourceProviderImpl resource_provider;
+    EXPECT_THROW_WITH_MESSAGE(
+        resource_provider.getResource(opentelemetry_config, context_), EnvoyException,
+        "Resource detector factory not found: "
+        "'envoy.tracers.opentelemetry.resource_detectors.AnotherUnkownResourceDetector'");
+  }
+}
+
+TEST_F(ResourceProviderTest, ProblemCreatingResourceDetector) {
+  UntypedDetectorFactory factory;
+  Registry::InjectFactory<ResourceDetectorFactory> factory_registration(factory);
+
+  // Simulating having a problem when creating the resource detector
+  EXPECT_CALL(factory, createResourceDetector(_)).WillOnce(Return(nullptr));
+
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    resource_detectors:
+      - name: envoy.tracers.opentelemetry.resource_detectors.untyped
+    )EOF";
+
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  ResourceProviderImpl resource_provider;
+  EXPECT_THROW_WITH_MESSAGE(resource_provider.getResource(opentelemetry_config, context_),
+                            EnvoyException,
+                            "Resource detector could not be created: "
+                            "'envoy.tracers.opentelemetry.resource_detectors.untyped'");
+}
+
+TEST_F(ResourceProviderTest, SchemaUrl) {
+  // old resource schema is empty but updating is not. should keep updating schema
+  {
+    std::string expected_schema_url = "my.schema/v1";
+    Resource old_resource = resource_untyped_;
+
+    Resource updating_resource = resource_typed_;
+    updating_resource.schemaUrl = expected_schema_url;
+
+    auto detector_untyped = std::make_shared<NiceMock<SampleDetector>>();
+    EXPECT_CALL(*detector_untyped, detect()).WillOnce(Return(old_resource));
+
+    auto detector_typed = std::make_shared<NiceMock<SampleDetector>>();
+    EXPECT_CALL(*detector_typed, detect()).WillOnce(Return(updating_resource));
+
+    UntypedDetectorFactory untyped_factory;
+    Registry::InjectFactory<ResourceDetectorFactory> untyped_factory_registration(untyped_factory);
+
+    TypedDetectorFactory typed_factory;
+    Registry::InjectFactory<ResourceDetectorTypedFactory> typed_factory_registration(typed_factory);
+
+    EXPECT_CALL(untyped_factory, createResourceDetector(_)).WillOnce(Return(detector_untyped));
+    EXPECT_CALL(typed_factory, createTypedResourceDetector(_, _)).WillOnce(Return(detector_typed));
+
+    const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    resource_detectors:
+      - name: envoy.tracers.opentelemetry.resource_detectors.untyped
+      - name: envoy.tracers.opentelemetry.resource_detectors.typed
+        typed_config:
+            "@type": type.googleapis.com/google.protobuf.Struct
+    )EOF";
+    envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+    TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+    ResourceProviderImpl resource_provider;
+    Resource resource = resource_provider.getResource(opentelemetry_config, context_);
+
+    EXPECT_EQ(expected_schema_url, resource.schemaUrl);
+  }
+  // old resource schema is not empty and updating one is. should keep old schema
+  {
+    std::string expected_schema_url = "my.schema/v1";
+    Resource old_resource = resource_untyped_;
+    old_resource.schemaUrl = expected_schema_url;
+
+    Resource updating_resource = resource_typed_;
+    updating_resource.schemaUrl = "";
+
+    auto detector_untyped = std::make_shared<NiceMock<SampleDetector>>();
+    EXPECT_CALL(*detector_untyped, detect()).WillOnce(Return(old_resource));
+
+    auto detector_typed = std::make_shared<NiceMock<SampleDetector>>();
+    EXPECT_CALL(*detector_typed, detect()).WillOnce(Return(updating_resource));
+
+    UntypedDetectorFactory untyped_factory;
+    Registry::InjectFactory<ResourceDetectorFactory> untyped_factory_registration(untyped_factory);
+
+    TypedDetectorFactory typed_factory;
+    Registry::InjectFactory<ResourceDetectorTypedFactory> typed_factory_registration(typed_factory);
+
+    EXPECT_CALL(untyped_factory, createResourceDetector(_)).WillOnce(Return(detector_untyped));
+    EXPECT_CALL(typed_factory, createTypedResourceDetector(_, _)).WillOnce(Return(detector_typed));
+
+    const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    resource_detectors:
+      - name: envoy.tracers.opentelemetry.resource_detectors.untyped
+      - name: envoy.tracers.opentelemetry.resource_detectors.typed
+        typed_config:
+            "@type": type.googleapis.com/google.protobuf.Struct
+    )EOF";
+    envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+    TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+    ResourceProviderImpl resource_provider;
+    Resource resource = resource_provider.getResource(opentelemetry_config, context_);
+
+    EXPECT_EQ(expected_schema_url, resource.schemaUrl);
+  }
+  // old and updating resource schema are the same. should keep old schema
+  {
+    std::string expected_schema_url = "my.schema/v1";
+    Resource old_resource = resource_untyped_;
+    old_resource.schemaUrl = expected_schema_url;
+
+    Resource updating_resource = resource_typed_;
+    updating_resource.schemaUrl = expected_schema_url;
+
+    auto detector_untyped = std::make_shared<NiceMock<SampleDetector>>();
+    EXPECT_CALL(*detector_untyped, detect()).WillOnce(Return(old_resource));
+
+    auto detector_typed = std::make_shared<NiceMock<SampleDetector>>();
+    EXPECT_CALL(*detector_typed, detect()).WillOnce(Return(updating_resource));
+
+    UntypedDetectorFactory untyped_factory;
+    Registry::InjectFactory<ResourceDetectorFactory> untyped_factory_registration(untyped_factory);
+
+    TypedDetectorFactory typed_factory;
+    Registry::InjectFactory<ResourceDetectorTypedFactory> typed_factory_registration(typed_factory);
+
+    EXPECT_CALL(untyped_factory, createResourceDetector(_)).WillOnce(Return(detector_untyped));
+    EXPECT_CALL(typed_factory, createTypedResourceDetector(_, _)).WillOnce(Return(detector_typed));
+
+    const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    resource_detectors:
+      - name: envoy.tracers.opentelemetry.resource_detectors.untyped
+      - name: envoy.tracers.opentelemetry.resource_detectors.typed
+        typed_config:
+            "@type": type.googleapis.com/google.protobuf.Struct
+    )EOF";
+    envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+    TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+    ResourceProviderImpl resource_provider;
+    Resource resource = resource_provider.getResource(opentelemetry_config, context_);
+
+    EXPECT_EQ(expected_schema_url, resource.schemaUrl);
+  }
+  // old and updating resource schema are not empty and are different. should keep old schema
+  {
+    std::string expected_schema_url = "my.schema/v1";
+    Resource old_resource = resource_untyped_;
+    old_resource.schemaUrl = expected_schema_url;
+
+    Resource updating_resource = resource_typed_;
+    updating_resource.schemaUrl = "my.schema/v2";
+
+    auto detector_untyped = std::make_shared<NiceMock<SampleDetector>>();
+    EXPECT_CALL(*detector_untyped, detect()).WillOnce(Return(old_resource));
+
+    auto detector_typed = std::make_shared<NiceMock<SampleDetector>>();
+    EXPECT_CALL(*detector_typed, detect()).WillOnce(Return(updating_resource));
+
+    UntypedDetectorFactory untyped_factory;
+    Registry::InjectFactory<ResourceDetectorFactory> untyped_factory_registration(untyped_factory);
+
+    TypedDetectorFactory typed_factory;
+    Registry::InjectFactory<ResourceDetectorTypedFactory> typed_factory_registration(typed_factory);
+
+    EXPECT_CALL(untyped_factory, createResourceDetector(_)).WillOnce(Return(detector_untyped));
+    EXPECT_CALL(typed_factory, createTypedResourceDetector(_, _)).WillOnce(Return(detector_typed));
+
+    const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    resource_detectors:
+      - name: envoy.tracers.opentelemetry.resource_detectors.untyped
+      - name: envoy.tracers.opentelemetry.resource_detectors.typed
+        typed_config:
+            "@type": type.googleapis.com/google.protobuf.Struct
+    )EOF";
+    envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+    TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+    ResourceProviderImpl resource_provider;
+    Resource resource = resource_provider.getResource(opentelemetry_config, context_);
+
+    EXPECT_EQ(expected_schema_url, resource.schemaUrl);
+  }
+}
+
+} // namespace
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/tools/extensions/extensions_schema.yaml
+++ b/tools/extensions/extensions_schema.yaml
@@ -132,6 +132,7 @@ categories:
 - envoy.http.early_header_mutation
 - envoy.http.custom_response
 - envoy.router.cluster_specifier_plugin
+- envoy.tracers.opentelemetry.resource_detectors
 
 status_values:
 - name: stable


### PR DESCRIPTION
This PR builds the foundation for adding resource detectors to the OpenTelemetry tracer in Envoy. It contains an initial resource detector that reads the `OTEL_RESOURCE_ATTRIBUTES` environment variable as per the OTel specification. 

Once this internal review round is done, I'll open the upstream PR. 