### PR TITLE
detect initial attributes for server spans, move span kind detection …

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -161,5 +161,8 @@ new_features:
     Ratelimit supports optional additional prefix to use when emitting statistics with :ref:`stat_prefix
     <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimit.stat_prefix>`
     configuration flag.
+- area: tracing
+  change: |
+    Provide initial span attributes to a sampler used in the OpenTelemetry tracer.
 
 deprecated:

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -155,14 +155,14 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
   if (!extractor.propagationHeaderPresent()) {
     // No propagation header, so we can create a fresh span with the given decision.
     Tracing::SpanPtr new_open_telemetry_span = tracer.startSpan(
-        operation_name, stream_info.startTime(), initial_attributes, tracing_decision, span_kind);
+        operation_name, stream_info.startTime(), tracing_decision, initial_attributes, span_kind);
     return new_open_telemetry_span;
   } else {
     // Try to extract the span context. If we can't, just return a null span.
     absl::StatusOr<SpanContext> span_context = extractor.extractSpanContext();
     if (span_context.ok()) {
-      return tracer.startSpan(operation_name, stream_info.startTime(), initial_attributes,
-                              span_context.value(), span_kind);
+      return tracer.startSpan(operation_name, stream_info.startTime(), span_context.value(),
+                              initial_attributes, span_kind);
     } else {
       ENVOY_LOG(trace, "Unable to extract span context: ", span_context.status());
       return std::make_unique<Tracing::NullSpan>();

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -43,6 +43,57 @@ tryCreateSamper(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemet
   return sampler;
 }
 
+OTelSpanAttributes getInitialAttributes(const Tracing::TraceContext& trace_context,
+                                        OTelSpanKind span_kind) {
+  OTelSpanAttributes attributes;
+
+  // required attributes for a server span are defined in
+  // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
+  if (span_kind == ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER) {
+    std::vector<absl::string_view> address_port =
+        absl::StrSplit(trace_context.host(), ":", absl::SkipEmpty());
+    if (address_port.size() > 0) {
+      attributes["server.address"] = address_port[0];
+    }
+    if (address_port.size() > 1) {
+      attributes["server.port"] = address_port[1];
+    }
+    std::vector<absl::string_view> path_query =
+        absl::StrSplit(trace_context.path(), "?", absl::SkipEmpty());
+    if (path_query.size() > 0) {
+      attributes["url.path"] = path_query[0];
+    }
+    if (path_query.size() > 1) {
+      attributes["url.query"] = path_query[1];
+    }
+    auto scheme = trace_context.getByKey(":scheme");
+    if (scheme.has_value()) {
+      attributes["url.scheme"] = scheme.value();
+    }
+    if (!trace_context.method().empty()) {
+      attributes["http.request.method"] = trace_context.method();
+    }
+  }
+  return attributes;
+}
+
+OTelSpanKind getSpanKind(const Tracing::Config& config) {
+  OTelSpanKind span_kind;
+  // If this is downstream span that be created by 'startSpan' for downstream request, then
+  // set the span type based on the spawnUpstreamSpan flag and traffic direction:
+  // * If separate tracing span will be created for upstream request, then set span type to
+  //   SERVER because the downstream span should be server span in trace chain.
+  // * If separate tracing span will not be created for upstream request, that means the
+  //   Envoy will not be treated as independent hop in trace chain and then set span type
+  //   based on the traffic direction.
+  span_kind =
+      (config.spawnUpstreamSpan() ? ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER
+       : config.operationName() == Tracing::OperationName::Egress
+           ? ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_CLIENT
+           : ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER);
+  return span_kind;
+}
+
 } // namespace
 
 Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetry_config,
@@ -99,17 +150,19 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
   // Get tracer from TLS and start span.
   auto& tracer = tls_slot_ptr_->getTyped<Driver::TlsTracer>().tracer();
   SpanContextExtractor extractor(trace_context);
+  auto span_kind = getSpanKind(config);
+  auto initial_attributes = getInitialAttributes(trace_context, span_kind);
   if (!extractor.propagationHeaderPresent()) {
     // No propagation header, so we can create a fresh span with the given decision.
-    Tracing::SpanPtr new_open_telemetry_span =
-        tracer.startSpan(config, operation_name, stream_info.startTime(), tracing_decision);
+    Tracing::SpanPtr new_open_telemetry_span = tracer.startSpan(
+        operation_name, stream_info.startTime(), initial_attributes, tracing_decision, span_kind);
     return new_open_telemetry_span;
   } else {
     // Try to extract the span context. If we can't, just return a null span.
     absl::StatusOr<SpanContext> span_context = extractor.extractSpanContext();
     if (span_context.ok()) {
-      return tracer.startSpan(config, operation_name, stream_info.startTime(),
-                              span_context.value());
+      return tracer.startSpan(operation_name, stream_info.startTime(), initial_attributes,
+                              span_context.value(), span_kind);
     } else {
       ENVOY_LOG(trace, "Unable to extract span context: ", span_context.status());
       return std::make_unique<Tracing::NullSpan>();

--- a/source/extensions/tracers/opentelemetry/samplers/always_on/always_on_sampler.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/always_on/always_on_sampler.cc
@@ -15,7 +15,7 @@ namespace OpenTelemetry {
 SamplingResult
 AlwaysOnSampler::shouldSample(const absl::optional<SpanContext> parent_context,
                               const std::string& /*trace_id*/, const std::string& /*name*/,
-                              ::opentelemetry::proto::trace::v1::Span::SpanKind /*kind*/,
+                              OTelSpanKind /*kind*/,
                               const std::map<std::string, std::string>& /*attributes*/,
                               const std::vector<SpanContext>& /*links*/) {
   SamplingResult result;

--- a/source/extensions/tracers/opentelemetry/samplers/always_on/always_on_sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/always_on/always_on_sampler.h
@@ -24,7 +24,7 @@ public:
                            Server::Configuration::TracerFactoryContext& /*context*/) {}
   SamplingResult shouldSample(const absl::optional<SpanContext> parent_context,
                               const std::string& trace_id, const std::string& name,
-                              ::opentelemetry::proto::trace::v1::Span::SpanKind spankind,
+                              OTelSpanKind spankind,
                               const std::map<std::string, std::string>& attributes,
                               const std::vector<SpanContext>& links) override;
   std::string getDescription() const override;

--- a/source/extensions/tracers/opentelemetry/samplers/sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/sampler.h
@@ -29,11 +29,25 @@ enum class Decision {
   RECORD_AND_SAMPLE
 };
 
+/**
+ * @brief A string key-value map that stores the span attributes.
+ * see
+ * https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
+ */
+using OTelSpanAttributes = std::map<std::string, std::string>;
+
+/**
+ * @brief The type of the span.
+ * see
+ * https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind
+ */
+using OTelSpanKind = ::opentelemetry::proto::trace::v1::Span::SpanKind;
+
 struct SamplingResult {
   /// @see Decision
   Decision decision;
   // A set of span Attributes that will also be added to the Span. Can be nullptr.
-  std::unique_ptr<const std::map<std::string, std::string>> attributes;
+  std::unique_ptr<const OTelSpanAttributes> attributes;
   // A Tracestate that will be associated with the Span. If the sampler
   // returns an empty Tracestate here, the Tracestate will be cleared, so samplers SHOULD normally
   // return the passed-in Tracestate if they do not intend to change it
@@ -70,8 +84,7 @@ public:
    */
   virtual SamplingResult shouldSample(const absl::optional<SpanContext> parent_context,
                                       const std::string& trace_id, const std::string& name,
-                                      ::opentelemetry::proto::trace::v1::Span::SpanKind spankind,
-                                      const std::map<std::string, std::string>& attributes,
+                                      OTelSpanKind spankind, const OTelSpanAttributes& attributes,
                                       const std::vector<SpanContext>& links) PURE;
 
   /**

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -62,7 +62,7 @@ Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& nam
                                   SystemTime start_time) {
   // Build span_context from the current span, then generate the child span from that context.
   SpanContext span_context(kDefaultVersion, getTraceIdAsHex(), spanId(), sampled(), tracestate());
-  return parent_tracer_.startSpan(name, start_time, {}, span_context,
+  return parent_tracer_.startSpan(name, start_time, span_context, {},
                                   ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_CLIENT);
 }
 
@@ -177,8 +177,10 @@ void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
 }
 
 Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name, SystemTime start_time,
+
+                                   Tracing::Decision tracing_decision,
                                    const OTelSpanAttributes& initial_attributes,
-                                   Tracing::Decision tracing_decision, OTelSpanKind span_kind) {
+                                   OTelSpanKind span_kind) {
   // Create an Tracers::OpenTelemetry::Span class that will contain the OTel span.
   Span new_span(operation_name, start_time, time_source_, *this, span_kind);
   uint64_t trace_id_high = random_.random();
@@ -195,8 +197,8 @@ Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name, SystemTime
 }
 
 Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name, SystemTime start_time,
-                                   const OTelSpanAttributes& initial_attributes,
                                    const SpanContext& previous_span_context,
+                                   const OTelSpanAttributes& initial_attributes,
                                    OTelSpanKind span_kind) {
   // Create a new span and populate details from the span context.
   Span new_span(operation_name, start_time, time_source_, *this, span_kind);

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -25,12 +25,14 @@ using opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
 namespace {
 
 void callSampler(SamplerSharedPtr sampler, const absl::optional<SpanContext> span_context,
-                 Span& new_span, const std::string& operation_name) {
+                 Span& new_span, const std::string& operation_name,
+                 const OTelSpanAttributes& initial_attributes) {
   if (!sampler) {
     return;
   }
-  const auto sampling_result = sampler->shouldSample(
-      span_context, operation_name, new_span.getTraceIdAsHex(), new_span.spankind(), {}, {});
+  const auto sampling_result =
+      sampler->shouldSample(span_context, operation_name, new_span.getTraceIdAsHex(),
+                            new_span.spankind(), initial_attributes, {});
   new_span.setSampled(sampling_result.isSampled());
 
   if (sampling_result.attributes) {
@@ -45,40 +47,23 @@ void callSampler(SamplerSharedPtr sampler, const absl::optional<SpanContext> spa
 
 } // namespace
 
-Span::Span(const Tracing::Config& config, const std::string& name, SystemTime start_time,
-           Envoy::TimeSource& time_source, Tracer& parent_tracer, bool downstream_span)
+Span::Span(const std::string& name, SystemTime start_time, Envoy::TimeSource& time_source,
+           Tracer& parent_tracer, OTelSpanKind span_kind)
     : parent_tracer_(parent_tracer), time_source_(time_source) {
   span_ = ::opentelemetry::proto::trace::v1::Span();
 
-  if (downstream_span) {
-    // If this is downstream span that be created by 'startSpan' for downstream request, then
-    // set the span type based on the spawnUpstreamSpan flag and traffic direction:
-    // * If separate tracing span will be created for upstream request, then set span type to
-    //   SERVER because the downstream span should be server span in trace chain.
-    // * If separate tracing span will not be created for upstream request, that means the
-    //   Envoy will not be treated as independent hop in trace chain and then set span type
-    //   based on the traffic direction.
-    span_.set_kind(config.spawnUpstreamSpan()
-                       ? ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER
-                   : config.operationName() == Tracing::OperationName::Egress
-                       ? ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_CLIENT
-                       : ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER);
-  } else {
-    // If this is an non-downstream span that be created for upstream request or async HTTP/gRPC
-    // request, then set the span type to client always.
-    span_.set_kind(::opentelemetry::proto::trace::v1::Span::SPAN_KIND_CLIENT);
-  }
+  span_.set_kind(span_kind);
 
   span_.set_name(name);
   span_.set_start_time_unix_nano(std::chrono::nanoseconds(start_time.time_since_epoch()).count());
 }
 
-Tracing::SpanPtr Span::spawnChild(const Tracing::Config& config, const std::string& name,
+Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& name,
                                   SystemTime start_time) {
   // Build span_context from the current span, then generate the child span from that context.
   SpanContext span_context(kDefaultVersion, getTraceIdAsHex(), spanId(), sampled(), tracestate());
-  return parent_tracer_.startSpan(config, name, start_time, span_context,
-                                  /*downstream_span*/ false);
+  return parent_tracer_.startSpan(name, start_time, {}, span_context,
+                                  ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_CLIENT);
 }
 
 void Span::finishSpan() {
@@ -191,29 +176,30 @@ void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
   }
 }
 
-Tracing::SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& operation_name,
-                                   SystemTime start_time, Tracing::Decision tracing_decision,
-                                   bool downstream_span) {
+Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name, SystemTime start_time,
+                                   const OTelSpanAttributes& initial_attributes,
+                                   Tracing::Decision tracing_decision, OTelSpanKind span_kind) {
   // Create an Tracers::OpenTelemetry::Span class that will contain the OTel span.
-  Span new_span(config, operation_name, start_time, time_source_, *this, downstream_span);
+  Span new_span(operation_name, start_time, time_source_, *this, span_kind);
   uint64_t trace_id_high = random_.random();
   uint64_t trace_id = random_.random();
   new_span.setTraceId(absl::StrCat(Hex::uint64ToHex(trace_id_high), Hex::uint64ToHex(trace_id)));
   uint64_t span_id = random_.random();
   new_span.setId(Hex::uint64ToHex(span_id));
   if (sampler_) {
-    callSampler(sampler_, absl::nullopt, new_span, operation_name);
+    callSampler(sampler_, absl::nullopt, new_span, operation_name, initial_attributes);
   } else {
     new_span.setSampled(tracing_decision.traced);
   }
   return std::make_unique<Span>(new_span);
 }
 
-Tracing::SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& operation_name,
-                                   SystemTime start_time, const SpanContext& previous_span_context,
-                                   bool downstream_span) {
+Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name, SystemTime start_time,
+                                   const OTelSpanAttributes& initial_attributes,
+                                   const SpanContext& previous_span_context,
+                                   OTelSpanKind span_kind) {
   // Create a new span and populate details from the span context.
-  Span new_span(config, operation_name, start_time, time_source_, *this, downstream_span);
+  Span new_span(operation_name, start_time, time_source_, *this, span_kind);
   new_span.setTraceId(previous_span_context.traceId());
   if (!previous_span_context.parentId().empty()) {
     new_span.setParentId(previous_span_context.parentId());
@@ -223,7 +209,7 @@ Tracing::SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::str
   new_span.setId(Hex::uint64ToHex(span_id));
   if (sampler_) {
     // Sampler should make a sampling decision and set tracestate
-    callSampler(sampler_, previous_span_context, new_span, operation_name);
+    callSampler(sampler_, previous_span_context, new_span, operation_name, initial_attributes);
   } else {
     // Respect the previous span's sampled flag.
     new_span.setSampled(previous_span_context.sampled());

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -42,13 +42,13 @@ public:
 
   void sendSpan(::opentelemetry::proto::trace::v1::Span& span);
 
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, const std::string& operation_name,
-                             SystemTime start_time, Tracing::Decision tracing_decision,
-                             bool downstream_span = true);
+  Tracing::SpanPtr startSpan(const std::string& operation_name, SystemTime start_time,
+                             const OTelSpanAttributes& initial_attributes,
+                             Tracing::Decision tracing_decision, OTelSpanKind span_kind);
 
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, const std::string& operation_name,
-                             SystemTime start_time, const SpanContext& previous_span_context,
-                             bool downstream_span = true);
+  Tracing::SpanPtr startSpan(const std::string& operation_name, SystemTime start_time,
+                             const OTelSpanAttributes& initial_attributes,
+                             const SpanContext& previous_span_context, OTelSpanKind span_kind);
 
 private:
   /**
@@ -77,8 +77,8 @@ private:
  */
 class Span : Logger::Loggable<Logger::Id::tracing>, public Tracing::Span {
 public:
-  Span(const Tracing::Config& config, const std::string& name, SystemTime start_time,
-       Envoy::TimeSource& time_source, Tracer& parent_tracer, bool downstream_span);
+  Span(const std::string& name, SystemTime start_time, Envoy::TimeSource& time_source,
+       Tracer& parent_tracer, OTelSpanKind span_kind);
 
   // Tracing::Span functions
   void setOperation(absl::string_view /*operation*/) override{};
@@ -115,7 +115,7 @@ public:
 
   std::string getTraceIdAsHex() const override { return absl::BytesToHexString(span_.trace_id()); };
 
-  ::opentelemetry::proto::trace::v1::Span::SpanKind spankind() const { return span_.kind(); }
+  OTelSpanKind spankind() const { return span_.kind(); }
 
   /**
    * Sets the span's id.

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -43,12 +43,13 @@ public:
   void sendSpan(::opentelemetry::proto::trace::v1::Span& span);
 
   Tracing::SpanPtr startSpan(const std::string& operation_name, SystemTime start_time,
-                             const OTelSpanAttributes& initial_attributes,
-                             Tracing::Decision tracing_decision, OTelSpanKind span_kind);
+
+                             Tracing::Decision tracing_decision,
+                             const OTelSpanAttributes& initial_attributes, OTelSpanKind span_kind);
 
   Tracing::SpanPtr startSpan(const std::string& operation_name, SystemTime start_time,
-                             const OTelSpanAttributes& initial_attributes,
-                             const SpanContext& previous_span_context, OTelSpanKind span_kind);
+                             const SpanContext& previous_span_context,
+                             const OTelSpanAttributes& initial_attributes, OTelSpanKind span_kind);
 
 private:
   /**

--- a/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
@@ -27,8 +27,7 @@ class TestSampler : public Sampler {
 public:
   MOCK_METHOD(SamplingResult, shouldSample,
               ((const absl::optional<SpanContext>), (const std::string&), (const std::string&),
-               (::opentelemetry::proto::trace::v1::Span::SpanKind),
-               (const std::map<std::string, std::string>&), (const std::vector<SpanContext>&)),
+               (OTelSpanKind), (const OTelSpanAttributes&), (const std::vector<SpanContext>&)),
               (override));
   MOCK_METHOD(std::string, getDescription, (), (const, override));
 };
@@ -134,8 +133,7 @@ TEST_F(SamplerFactoryTest, TestWithSampler) {
   // shouldSample returns a result without additional attributes and Decision::RECORD_AND_SAMPLE
   EXPECT_CALL(*test_sampler, shouldSample(_, _, _, _, _, _))
       .WillOnce([](const absl::optional<SpanContext>, const std::string&, const std::string&,
-                   ::opentelemetry::proto::trace::v1::Span::SpanKind,
-                   const std::map<std::string, std::string>&, const std::vector<SpanContext>&) {
+                   OTelSpanKind, const OTelSpanAttributes&, const std::vector<SpanContext>&) {
         SamplingResult res;
         res.decision = Decision::RECORD_AND_SAMPLE;
         res.tracestate = "this_is=tracesate";
@@ -154,15 +152,13 @@ TEST_F(SamplerFactoryTest, TestWithSampler) {
   // shouldSamples return a result containing additional attributes and Decision::DROP
   EXPECT_CALL(*test_sampler, shouldSample(_, _, _, _, _, _))
       .WillOnce([](const absl::optional<SpanContext>, const std::string&, const std::string&,
-                   ::opentelemetry::proto::trace::v1::Span::SpanKind,
-                   const std::map<std::string, std::string>&, const std::vector<SpanContext>&) {
+                   OTelSpanKind, const OTelSpanAttributes&, const std::vector<SpanContext>&) {
         SamplingResult res;
         res.decision = Decision::DROP;
-        std::map<std::string, std::string> attributes;
+        OTelSpanAttributes attributes;
         attributes["key"] = "value";
         attributes["another_key"] = "another_value";
-        res.attributes =
-            std::make_unique<const std::map<std::string, std::string>>(std::move(attributes));
+        res.attributes = std::make_unique<const OTelSpanAttributes>(std::move(attributes));
         res.tracestate = "this_is=another_tracesate";
         return res;
       });
@@ -171,6 +167,83 @@ TEST_F(SamplerFactoryTest, TestWithSampler) {
   std::unique_ptr<Span> unsampled_span(dynamic_cast<Span*>(tracing_span.release()));
   EXPECT_FALSE(unsampled_span->sampled());
   EXPECT_STREQ(unsampled_span->tracestate().c_str(), "this_is=another_tracesate");
+}
+
+// Test OTLP tracer with a sampler
+TEST_F(SamplerFactoryTest, TestInitialAttributes) {
+  auto test_sampler = std::make_shared<NiceMock<TestSampler>>();
+  TestSamplerFactory sampler_factory;
+  Registry::InjectFactory<SamplerFactory> sampler_factory_registration(sampler_factory);
+
+  EXPECT_CALL(sampler_factory, createSampler(_, _)).WillOnce(Return(test_sampler));
+
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    sampler:
+      name: envoy.tracers.opentelemetry.samplers.testsampler
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+    )EOF";
+
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  auto driver = std::make_unique<Driver>(opentelemetry_config, context);
+
+  // set all expected values
+  trace_context.context_method_ = "GET";
+  trace_context.context_host_ = "localhost:1234";
+  trace_context.context_path_ = "/path?query";
+  trace_context.setByReference(":scheme", "http");
+  OTelSpanAttributes expected = {{"http.request.method", "GET"}, {"server.address", "localhost"},
+                                 {"server.port", "1234"},        {"url.path", "/path"},
+                                 {"url.query", "query"},         {"url.scheme", "http"}};
+
+  EXPECT_CALL(*test_sampler, shouldSample(_, _, _, _, expected, _));
+  driver->startSpan(config, trace_context, stream_info, "operation_name",
+                    {Tracing::Reason::Sampling, true});
+
+  // no port, no path
+  trace_context.context_method_ = "POST";
+  trace_context.context_host_ = "localhost";
+  trace_context.context_path_ = "/path";
+  trace_context.setByReference(":scheme", "http");
+  expected = {{"http.request.method", "POST"},
+              {"server.address", "localhost"},
+              {"url.path", "/path"},
+              {"url.scheme", "http"}};
+
+  EXPECT_CALL(*test_sampler, shouldSample(_, _, _, _, expected, _));
+  driver->startSpan(config, trace_context, stream_info, "operation_name",
+                    {Tracing::Reason::Sampling, true});
+
+  // no port, query without path
+  trace_context.context_method_ = "POST";
+  trace_context.context_host_ = "127.0.0.1";
+  trace_context.context_path_ = "?asdf";
+  trace_context.setByReference(":scheme", "http");
+  expected = {{"http.request.method", "POST"},
+              {"server.address", "127.0.0.1"},
+              {"url.path", "asdf"},
+              {"url.scheme", "http"}};
+
+  EXPECT_CALL(*test_sampler, shouldSample(_, _, _, _, expected, _));
+  driver->startSpan(config, trace_context, stream_info, "operation_name",
+                    {Tracing::Reason::Sampling, true});
+
+  // all empty
+  trace_context.context_method_ = "";
+  trace_context.context_host_ = "";
+  trace_context.context_path_ = "";
+  trace_context.removeByKey(":scheme");
+  expected.clear();
+  EXPECT_CALL(*test_sampler, shouldSample(_, _, _, _, expected, _));
+  driver->startSpan(config, trace_context, stream_info, "operation_name",
+                    {Tracing::Reason::Sampling, true});
 }
 
 // Test sampling result decision


### PR DESCRIPTION
**Commit Message:** detect initial attributes for server spans, move span kind detection to Driver::startSpan
**Additional Description:**
A sampler API was added to Envoy in https://github.com/envoyproxy/envoy/pull/30259. The sampler API allows to provide initial span attributes to a sampler so they can be considered for sampling decisions. This PR provides a set of initial span attributes when a sampler is called.
**Risk Level:** LOW
**Testing:** Extendend/added unit test, Covered by existing OpenTelemetryDriverTest, manual
**Docs Changes:**  N/A 
**Release Notes:** N/A 
**Platform Specific Features:**  N/A 
Fixes: 