### PR TITLE
opentelemetrytracer: Allow sampler to set variant type span attributes

### DIFF
--- a/source/extensions/tracers/opentelemetry/BUILD
+++ b/source/extensions/tracers/opentelemetry/BUILD
@@ -26,11 +26,13 @@ envoy_cc_library(
     name = "opentelemetry_tracer_lib",
     srcs = [
         "opentelemetry_tracer_impl.cc",
+        "otlp_utils.cc",
         "span_context_extractor.cc",
         "tracer.cc",
     ],
     hdrs = [
         "opentelemetry_tracer_impl.h",
+        "otlp_utils.h",
         "span_context.h",
         "span_context_extractor.h",
         "tracer.h",

--- a/source/extensions/tracers/opentelemetry/otlp_utils.cc
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.cc
@@ -1,0 +1,47 @@
+#include "source/extensions/tracers/opentelemetry/otlp_utils.h"
+
+#include <cstdint>
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+void OtlpUtils::populateAnyValue(opentelemetry::proto::common::v1::AnyValue& value_proto,
+                                 const OTelAttribute& attribute_value) {
+  switch (attribute_value.index()) {
+  case opentelemetry::common::AttributeType::kTypeBool:
+    value_proto.set_bool_value(opentelemetry::nostd::get<bool>(attribute_value) ? true : false);
+    break;
+  case opentelemetry::common::AttributeType::kTypeInt:
+    value_proto.set_int_value(opentelemetry::nostd::get<int32_t>(attribute_value));
+    break;
+  case opentelemetry::common::AttributeType::kTypeInt64:
+    value_proto.set_int_value(opentelemetry::nostd::get<int64_t>(attribute_value));
+    break;
+  case opentelemetry::common::AttributeType::kTypeUInt:
+    value_proto.set_int_value(opentelemetry::nostd::get<uint32_t>(attribute_value));
+    break;
+  case opentelemetry::common::AttributeType::kTypeUInt64:
+    value_proto.set_int_value(opentelemetry::nostd::get<uint64_t>(attribute_value));
+    break;
+  case opentelemetry::common::AttributeType::kTypeDouble:
+    value_proto.set_double_value(opentelemetry::nostd::get<double>(attribute_value));
+    break;
+  case opentelemetry::common::AttributeType::kTypeCString:
+    value_proto.set_string_value(opentelemetry::nostd::get<const char*>(attribute_value));
+    break;
+  case opentelemetry::common::AttributeType::kTypeString: {
+    value_proto.set_string_value(
+        opentelemetry::nostd::get<opentelemetry::nostd::string_view>(attribute_value).data(),
+        opentelemetry::nostd::get<opentelemetry::nostd::string_view>(attribute_value).size());
+  } break;
+  default:
+    return;
+  }
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/otlp_utils.h
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "source/extensions/tracers/opentelemetry/samplers/sampler.h"
+
+#include "opentelemetry/proto/common/v1/common.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * Contains utility functions  for Otel
+ */
+class OtlpUtils {
+
+public:
+  /**
+   * @brief Set the Otel attribute on a Proto Value object
+   *
+   * @param value_proto Proto object which gets the value set.
+   * @param attribute_value Value to set on the proto object.
+   */
+  static void populateAnyValue(opentelemetry::proto::common::v1::AnyValue& value_proto,
+                               const OTelAttribute& attribute_value);
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler.cc
@@ -85,14 +85,15 @@ private:
 };
 
 // add Dynatrace specific span attributes
-void addSamplingAttributes(uint32_t sampling_exponent,
-                           std::map<std::string, std::string>& attributes) {
+void addSamplingAttributes(
+    uint32_t sampling_exponent,
+    std::map<std::string, opentelemetry::common::AttributeValue>& attributes) {
 
   const auto multiplicity = SamplingState::toMultiplicity(sampling_exponent);
   // The denominator of the sampling ratio. If, for example, the Dynatrace OneAgent samples with a
   // probability of 1/16, the value of supportability sampling ratio would be 16.
   // Note: Ratio is also known as multiplicity.
-  attributes["supportability.atm_sampling_ratio"] = std::to_string(multiplicity);
+  attributes["supportability.atm_sampling_ratio"] = multiplicity;
 
   if (multiplicity > 1) {
     static constexpr uint64_t two_pow_56 = 1llu << 56; // 2^56
@@ -100,7 +101,7 @@ void addSamplingAttributes(uint32_t sampling_exponent,
     // that are discarded out of 2^56. The attribute is only available if the sampling.threshold is
     // not 0 and therefore sampling happened.
     const uint64_t sampling_threshold = two_pow_56 - two_pow_56 / multiplicity;
-    attributes["sampling.threshold"] = std::to_string(sampling_threshold);
+    attributes["sampling.threshold"] = sampling_threshold;
   }
 }
 
@@ -129,7 +130,7 @@ SamplingResult DynatraceSampler::shouldSample(const absl::optional<SpanContext> 
                                               const std::vector<SpanContext>& /*links*/) {
 
   SamplingResult result;
-  std::map<std::string, std::string> att;
+  std::map<std::string, opentelemetry::common::AttributeValue> att;
 
   // trace_context->path() returns path and query. query part is removed in getSamplingKey()
   const std::string sampling_key =
@@ -175,8 +176,11 @@ SamplingResult DynatraceSampler::shouldSample(const absl::optional<SpanContext> 
   }
 
   if (!att.empty()) {
-    result.attributes = std::make_unique<const std::map<std::string, std::string>>(std::move(att));
+    result.attributes =
+        std::make_unique<const std::map<std::string, opentelemetry::common::AttributeValue>>(
+            std::move(att));
   }
+
   return result;
 }
 

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler.cc
@@ -85,9 +85,8 @@ private:
 };
 
 // add Dynatrace specific span attributes
-void addSamplingAttributes(
-    uint32_t sampling_exponent,
-    std::map<std::string, opentelemetry::common::AttributeValue>& attributes) {
+void addSamplingAttributes(uint32_t sampling_exponent,
+                           std::map<std::string, OTelAttribute>& attributes) {
 
   const auto multiplicity = SamplingState::toMultiplicity(sampling_exponent);
   // The denominator of the sampling ratio. If, for example, the Dynatrace OneAgent samples with a
@@ -130,7 +129,7 @@ SamplingResult DynatraceSampler::shouldSample(const absl::optional<SpanContext> 
                                               const std::vector<SpanContext>& /*links*/) {
 
   SamplingResult result;
-  std::map<std::string, opentelemetry::common::AttributeValue> att;
+  std::map<std::string, OTelAttribute> att;
 
   // trace_context->path() returns path and query. query part is removed in getSamplingKey()
   const std::string sampling_key =
@@ -177,8 +176,7 @@ SamplingResult DynatraceSampler::shouldSample(const absl::optional<SpanContext> 
 
   if (!att.empty()) {
     result.attributes =
-        std::make_unique<const std::map<std::string, opentelemetry::common::AttributeValue>>(
-            std::move(att));
+        std::make_unique<const std::map<std::string, OTelAttribute>>(std::move(att));
   }
 
   return result;

--- a/source/extensions/tracers/opentelemetry/samplers/sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/sampler.h
@@ -38,11 +38,18 @@ enum class Decision {
  */
 using OTelSpanKind = ::opentelemetry::proto::trace::v1::Span::SpanKind;
 
+/**
+ * @brief Open-telemetry Attribute
+ * see
+ * https://github.com/open-telemetry/opentelemetry-cpp/blob/main/api/include/opentelemetry/common/attribute_value.h
+ */
+using OTelAttribute = ::opentelemetry::common::AttributeValue;
+
 struct SamplingResult {
   /// @see Decision
   Decision decision;
   // A set of span Attributes that will also be added to the Span. Can be nullptr.
-  std::unique_ptr<const std::map<std::string, opentelemetry::common::AttributeValue>> attributes;
+  std::unique_ptr<const std::map<std::string, OTelAttribute>> attributes;
   // A Tracestate that will be associated with the Span. If the sampler
   // returns an empty Tracestate here, the Tracestate will be cleared, so samplers SHOULD normally
   // return the passed-in Tracestate if they do not intend to change it

--- a/source/extensions/tracers/opentelemetry/samplers/sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/sampler.h
@@ -11,6 +11,7 @@
 #include "envoy/tracing/trace_context.h"
 
 #include "absl/types/optional.h"
+#include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/proto/trace/v1/trace.pb.h"
 
 namespace Envoy {
@@ -41,7 +42,7 @@ struct SamplingResult {
   /// @see Decision
   Decision decision;
   // A set of span Attributes that will also be added to the Span. Can be nullptr.
-  std::unique_ptr<const std::map<std::string, std::string>> attributes;
+  std::unique_ptr<const std::map<std::string, opentelemetry::common::AttributeValue>> attributes;
   // A Tracestate that will be associated with the Span. If the sampler
   // returns an empty Tracestate here, the Tracestate will be cleared, so samplers SHOULD normally
   // return the passed-in Tracestate if they do not intend to change it

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -47,14 +47,13 @@ void callSampler(SamplerSharedPtr sampler, const absl::optional<SpanContext> spa
       new_span.setAttribute(attribute.first, attribute.second);
     }
   }
-
   if (!sampling_result.tracestate.empty()) {
     new_span.setTracestate(sampling_result.tracestate);
   }
 }
 
 void setProtoValue(opentelemetry::proto::common::v1::AnyValue& value_proto,
-                   const opentelemetry::common::AttributeValue& attribute_value) {
+                   const OTelAttribute& attribute_value) {
   switch (attribute_value.index()) {
   case opentelemetry::common::AttributeType::kTypeBool:
     value_proto.set_bool_value(opentelemetry::nostd::get<bool>(attribute_value) ? true : false);
@@ -131,8 +130,7 @@ void Span::injectContext(Tracing::TraceContext& trace_context,
   traceStateHeader().setRefKey(trace_context, span_.trace_state());
 }
 
-void Span::setAttribute(absl::string_view name,
-                        const opentelemetry::common::AttributeValue& attribute_value) {
+void Span::setAttribute(absl::string_view name, const OTelAttribute& attribute_value) {
   // The attribute key MUST be a non-null and non-empty string.
   if (name.empty()) {
     return;

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -145,7 +145,12 @@ public:
   void setTracestate(const absl::string_view& tracestate) {
     span_.set_trace_state(std::string{tracestate});
   }
-  void setAttribute(absl::string_view name, const opentelemetry::common::AttributeValue& value);
+
+  /**
+   * Sets a span attribute.
+   */
+  void setAttribute(absl::string_view name, const OTelAttribute& value);
+
   /**
    * Method to access the span for testing.
    */

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -145,7 +145,7 @@ public:
   void setTracestate(const absl::string_view& tracestate) {
     span_.set_trace_state(std::string{tracestate});
   }
-
+  void setAttribute(absl::string_view name, const opentelemetry::common::AttributeValue& value);
   /**
    * Method to access the span for testing.
    */

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_test.cc
@@ -80,8 +80,9 @@ TEST_F(DynatraceSamplerTest, TestWithoutParentContext) {
                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
   EXPECT_EQ(sampling_result.attributes->size(), 1);
-  EXPECT_STREQ(
-      sampling_result.attributes->find("supportability.atm_sampling_ratio")->second.c_str(), "1");
+  EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(
+                sampling_result.attributes->find("supportability.atm_sampling_ratio")->second),
+            1);
   EXPECT_STREQ(sampling_result.tracestate.c_str(), "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95");
   EXPECT_TRUE(sampling_result.isRecording());
   EXPECT_TRUE(sampling_result.isSampled());
@@ -96,8 +97,9 @@ TEST_F(DynatraceSamplerTest, TestWithUnknownParentContext) {
                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
   EXPECT_EQ(sampling_result.attributes->size(), 1);
-  EXPECT_STREQ(
-      sampling_result.attributes->find("supportability.atm_sampling_ratio")->second.c_str(), "1");
+  EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(
+                sampling_result.attributes->find("supportability.atm_sampling_ratio")->second),
+            1);
   // Dynatrace tracestate should be prepended
   EXPECT_STREQ(sampling_result.tracestate.c_str(),
                "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95,some_vendor=some_value");
@@ -114,8 +116,9 @@ TEST_F(DynatraceSamplerTest, TestWithDynatraceParentContextSampled) {
                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
   EXPECT_EQ(sampling_result.attributes->size(), 1);
-  EXPECT_STREQ(
-      sampling_result.attributes->find("supportability.atm_sampling_ratio")->second.c_str(), "1");
+  EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(
+                sampling_result.attributes->find("supportability.atm_sampling_ratio")->second),
+            1);
   // tracestate should be forwarded
   EXPECT_STREQ(sampling_result.tracestate.c_str(), dt_tracestate_sampled);
   // sampling decision from parent should be respected
@@ -183,10 +186,13 @@ TEST_F(DynatraceSamplerTest, TestWithDynatraceParentContextIgnored) {
                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   EXPECT_EQ(sampling_result.decision, Decision::Drop);
   EXPECT_EQ(sampling_result.attributes->size(), 2);
-  EXPECT_STREQ(
-      sampling_result.attributes->find("supportability.atm_sampling_ratio")->second.c_str(), "4");
-  EXPECT_STREQ(sampling_result.attributes->find("sampling.threshold")->second.c_str(),
-               "54043195528445952");
+  EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(
+                sampling_result.attributes->find("supportability.atm_sampling_ratio")->second),
+            4);
+  EXPECT_EQ(opentelemetry::nostd::get<uint64_t>(
+                sampling_result.attributes->find("sampling.threshold")->second),
+            54043195528445952);
+
   // tracestate should be forwarded
   EXPECT_STREQ(sampling_result.tracestate.c_str(), dt_tracestate_ignored);
   // sampling decision from parent should be respected
@@ -205,8 +211,9 @@ TEST_F(DynatraceSamplerTest, TestWithDynatraceParentContextFromDifferentTenant) 
   // sampling decision on tracestate should be ignored because it is from a different tenant.
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
   EXPECT_EQ(sampling_result.attributes->size(), 1);
-  EXPECT_STREQ(
-      sampling_result.attributes->find("supportability.atm_sampling_ratio")->second.c_str(), "1");
+  EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(
+                sampling_result.attributes->find("supportability.atm_sampling_ratio")->second),
+            1);
   // new Dynatrace tag should be prepended, already existing tag should be kept
   const char* exptected =
       "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95,6666ad40-980df25c@dt=fw4;4;4af38366;0;0;1;2;123;"

--- a/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
@@ -165,7 +165,7 @@ TEST_F(SamplerFactoryTest, TestWithSampler) {
                    const std::vector<SpanContext>&) {
         SamplingResult res;
         res.decision = Decision::Drop;
-        std::map<std::string, opentelemetry::common::AttributeValue> attributes;
+        std::map<std::string, OTelAttribute> attributes;
         attributes["char_key"] = "char_value";
         attributes["sv_key"] = absl::string_view("sv_value");
         attributes["bool_key"] = true;
@@ -177,8 +177,7 @@ TEST_F(SamplerFactoryTest, TestWithSampler) {
         attributes["not_supported_span"] = opentelemetry::nostd::span<bool>();
 
         res.attributes =
-            std::make_unique<const std::map<std::string, opentelemetry::common::AttributeValue>>(
-                std::move(attributes));
+            std::make_unique<const std::map<std::string, OTelAttribute>>(std::move(attributes));
         res.tracestate = "this_is=another_tracesate";
         return res;
       });

--- a/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
@@ -165,11 +165,20 @@ TEST_F(SamplerFactoryTest, TestWithSampler) {
                    const std::vector<SpanContext>&) {
         SamplingResult res;
         res.decision = Decision::Drop;
-        std::map<std::string, std::string> attributes;
-        attributes["key"] = "value";
-        attributes["another_key"] = "another_value";
+        std::map<std::string, opentelemetry::common::AttributeValue> attributes;
+        attributes["char_key"] = "char_value";
+        attributes["sv_key"] = absl::string_view("sv_value");
+        attributes["bool_key"] = true;
+        attributes["int_key"] = static_cast<int32_t>(123);
+        attributes["uint_key"] = static_cast<uint32_t>(123);
+        attributes["int64_t_key"] = static_cast<int64_t>(INT64_MAX);
+        attributes["uint64_t_key"] = static_cast<uint64_t>(UINT64_MAX);
+        attributes["double_key"] = 0.123;
+        attributes["not_supported_span"] = opentelemetry::nostd::span<bool>();
+
         res.attributes =
-            std::make_unique<const std::map<std::string, std::string>>(std::move(attributes));
+            std::make_unique<const std::map<std::string, opentelemetry::common::AttributeValue>>(
+                std::move(attributes));
         res.tracestate = "this_is=another_tracesate";
         return res;
       });
@@ -178,6 +187,41 @@ TEST_F(SamplerFactoryTest, TestWithSampler) {
   std::unique_ptr<Span> unsampled_span(dynamic_cast<Span*>(tracing_span.release()));
   EXPECT_FALSE(unsampled_span->sampled());
   EXPECT_STREQ(unsampled_span->tracestate().c_str(), "this_is=another_tracesate");
+  auto proto_span = unsampled_span->spanForTest();
+
+  auto get_attr_value =
+      [&proto_span](const char* name) -> ::opentelemetry::proto::common::v1::AnyValue* {
+    for (auto& key_value : *proto_span.mutable_attributes()) {
+      if (key_value.key() == name) {
+        return key_value.mutable_value();
+      }
+    }
+    return nullptr;
+  };
+
+  ASSERT_NE(get_attr_value("char_key"), nullptr);
+  EXPECT_STREQ(get_attr_value("char_key")->string_value().c_str(), "char_value");
+
+  ASSERT_NE(get_attr_value("sv_key"), nullptr);
+  EXPECT_STREQ(get_attr_value("sv_key")->string_value().c_str(), "sv_value");
+
+  ASSERT_NE(get_attr_value("bool_key"), nullptr);
+  EXPECT_EQ(get_attr_value("bool_key")->bool_value(), true);
+
+  ASSERT_NE(get_attr_value("int_key"), nullptr);
+  EXPECT_EQ(get_attr_value("int_key")->int_value(), 123);
+
+  ASSERT_NE(get_attr_value("uint_key"), nullptr);
+  EXPECT_EQ(get_attr_value("uint_key")->int_value(), 123);
+
+  ASSERT_NE(get_attr_value("int64_t_key"), nullptr);
+  EXPECT_EQ(get_attr_value("int64_t_key")->int_value(), INT64_MAX);
+
+  ASSERT_NE(get_attr_value("uint64_t_key"), nullptr);
+  EXPECT_EQ(get_attr_value("uint64_t_key")->int_value(), UINT64_MAX);
+
+  ASSERT_NE(get_attr_value("double_key"), nullptr);
+  EXPECT_EQ(get_attr_value("double_key")->double_value(), 0.123);
 }
 
 // Test that sampler receives trace_context


### PR DESCRIPTION
Commit Message: Allow sampler to set variant type span attributes
Additional Description: The opentelemetry sampler interface allows a sampler to add span attributes. The current Envoy implementation has the limitation that only string attributes are allowed.
In [#32333](https://github.com/envoyproxy/envoy/pull/32333) a dependency to Otel C++ API was added. This enables us to use the same type for attributes as Otel C++ SDK does. 
Risk Level:
Testing: Unit, Integration, Manual
Docs Changes: N/A
Release Notes: Allow sampler to set variant type span attributes
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
