### PR TITLE
opentelemetrytracer: Dynatrace sampler: Use http_service in configuration.

### DIFF
--- a/api/envoy/extensions/tracers/opentelemetry/samplers/v3/dynatrace_sampler.proto
+++ b/api/envoy/extensions/tracers/opentelemetry/samplers/v3/dynatrace_sampler.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package envoy.extensions.tracers.opentelemetry.samplers.v3;
 
-import "envoy/config/core/v3/http_uri.proto";
+import "envoy/config/core/v3/http_service.proto";
 
 import "udpa/annotations/status.proto";
 
@@ -15,8 +15,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: Dynatrace Sampler config]
 // Configuration for the Dynatrace Sampler extension.
 // [#extension: envoy.tracers.opentelemetry.samplers.dynatrace]
-
-// [#next-free-field: 6]
 message DynatraceSamplerConfig {
   // The Dynatrace tenant.
   //
@@ -28,19 +26,20 @@ message DynatraceSamplerConfig {
   // The value can be obtained from the Envoy deployment page in Dynatrace.
   int32 cluster_id = 2;
 
-  // The HTTP URI to fetch the sampler configuration (root spans per minute). For example:
+  // The HTTP service to fetch the sampler configuration (root spans per minute). For example:
   //
   // .. code-block:: yaml
+  //    http_service:
+  //      http_uri:
+  //        cluster: dynatrace
+  //        uri: <tenant>.dev.dynatracelabs.com/api/v2/samplingConfiguration
+  //        timeout: 10s
+  //      request_headers_to_add:
+  //      - header:
+  //          key : "authorization"
+  //          value: "Api-Token dt..."
   //
-  //    http_uri:
-  //      uri: <tenant>.dev.dynatracelabs.com/api/v2/samplingConfiguration
-  //      cluster: dynatrace
-  //      timeout: 10s
-  //
-  config.core.v3.HttpUri http_uri = 3;
-
-  // The access token to fetch the sampling configuration from the Dynatrace API
-  string token = 4;
+  config.core.v3.HttpService http_service = 3;
 
   // Default number of root spans per minute, used when the value can't be obtained from the Dynatrace API.
   //
@@ -49,5 +48,5 @@ message DynatraceSamplerConfig {
   // - ``root_spans_per_minute`` is unset
   // - ``root_spans_per_minute`` is set to 0
   //
-  uint32 root_spans_per_minute = 5;
+  uint32 root_spans_per_minute = 4;
 }

--- a/api/envoy/extensions/tracers/opentelemetry/samplers/v3/dynatrace_sampler.proto
+++ b/api/envoy/extensions/tracers/opentelemetry/samplers/v3/dynatrace_sampler.proto
@@ -26,7 +26,7 @@ message DynatraceSamplerConfig {
   // The value can be obtained from the Envoy deployment page in Dynatrace.
   int32 cluster_id = 2;
 
-  // The HTTP service to fetch the sampler configuration (root spans per minute). For example:
+  // The HTTP service to fetch the sampler configuration from the Dynatrace API (root spans per minute). For example:
   //
   // .. code-block:: yaml
   //    http_service:

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/BUILD
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/BUILD
@@ -41,6 +41,7 @@ envoy_cc_library(
         "//source/common/config:datasource_lib",
         "//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",
         "//source/extensions/tracers/opentelemetry/samplers:sampler_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider.h
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider.h
@@ -4,6 +4,8 @@
 #include <utility>
 #include <vector>
 
+#include "envoy/config/core/v3/http_service.pb.h"
+#include "envoy/config/core/v3/http_uri.pb.h"
 #include "envoy/extensions/tracers/opentelemetry/samplers/v3/dynatrace_sampler.pb.h"
 #include "envoy/http/async_client.h"
 #include "envoy/http/message.h"
@@ -65,7 +67,7 @@ private:
   Event::TimerPtr timer_;
   Upstream::ClusterManager& cluster_manager_;
   envoy::config::core::v3::HttpUri http_uri_;
-  const std::string authorization_header_value_;
+  std::vector<std::pair<const Http::LowerCaseString, const std::string>> parsed_headers_to_add_;
   Http::AsyncClient::Request* active_request_{};
   SamplerConfig sampler_config_;
 };

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider_test.cc
@@ -62,7 +62,6 @@ protected:
 };
 
 MATCHER_P(MessageMatcher, unusedArg, "") {
-  // prefix 'Api-Token' should be added to 'tokenval' set via SamplerConfigProvider constructor
   return (arg->headers()
               .get(Http::CustomHeaders::get().Authorization)[0]
               ->value()

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider_test.cc
@@ -31,11 +31,15 @@ public:
     const std::string yaml_string = R"EOF(
           tenant: "abc12345"
           cluster_id: -1743916452
-          token: "tokenval"
-          http_uri:
-            cluster: "cluster_name"
-            uri: "https://testhost.com/api/v2/samplingConfiguration"
-            timeout: 0.250s
+          http_service:
+            http_uri:
+              cluster: "cluster_name"
+              uri: "https://testhost.com/api/v2/samplingConfiguration"
+              timeout: 0.250s
+            request_headers_to_add:
+            - header:
+                key: "authorization"
+                value: "Api-Token tokenval"
           root_spans_per_minute: 1000
     )EOF";
     TestUtility::loadFromYaml(yaml_string, proto_config_);
@@ -206,11 +210,11 @@ TEST_F(SamplerConfigProviderTest, TestValueConfigured) {
   const std::string yaml_string = R"EOF(
           tenant: "abc12345"
           cluster_id: -1743916452
-          token: "tokenval"
-          http_uri:
-            cluster: "cluster_name"
-            uri: "https://testhost.com/otlp/v1/traces"
-            timeout: 0.250s
+          http_service:
+            http_uri:
+              cluster: "cluster_name"
+              uri: "https://testhost.com/otlp/v1/traces"
+              timeout: 0.250s
           root_spans_per_minute: 3456
     )EOF";
 
@@ -226,11 +230,11 @@ TEST_F(SamplerConfigProviderTest, TestNoValueConfigured) {
   const std::string yaml_string = R"EOF(
           tenant: "abc12345"
           cluster_id: -1743916452
-          token: "tokenval"
-          http_uri:
-            cluster: "cluster_name"
-            uri: "https://testhost.com/otlp/v1/traces"
-            timeout: 500s
+          http_service:
+            http_uri:
+              cluster: "cluster_name"
+              uri: "https://testhost.com/otlp/v1/traces"
+              timeout: 500s
     )EOF";
 
   envoy::extensions::tracers::opentelemetry::samplers::v3::DynatraceSamplerConfig proto_config;
@@ -246,11 +250,11 @@ TEST_F(SamplerConfigProviderTest, TestValueZeroConfigured) {
   const std::string yaml_string = R"EOF(
           tenant: "abc12345"
           cluster_id: -1743916452
-          token: "tokenval"
-          http_uri:
-            cluster: "cluster_name"
-            uri: "https://testhost.com/otlp/v1/traces"
-            timeout: 0.250s
+          http_service:
+            http_uri:
+              cluster: "cluster_name"
+              uri: "https://testhost.com/otlp/v1/traces"
+              timeout: 0.250s
           root_spans_per_minute: 0
     )EOF";
 


### PR DESCRIPTION
Commit Message: change Dynatrace sampler config to use http_service
Additional Description: In [#32598](https://github.com/envoyproxy/envoy/pull/32598) a custom Dynatrace sampler was added to Envoy. This sampler fetches its configuration via an HTTP call from a Dynatrace cluster. The endpoint and some additional information required to perform the HTTP call can be set in the Envoy config file.
While working on Istio changes to allow to set the endpoint, it turned out that it would be easier to use `http_service` instead of `http_uri`. 
This also allows to configure additional HTTP headers which are added to the request.
Another benefit is that the configuration is now aligned to the HTTP exporter, see https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/trace/v3/opentelemetry.proto#L42

Since the Dynatrace sampler is not yet released it should be ok to do config breaking change.

Risk Level: LOW
Testing: Unit, Integration, Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue] N/A
[Optional Fixes commit #PR or SHA]  [#32598](https://github.com/envoyproxy/envoy/pull/32598), [#32848](https://github.com/envoyproxy/envoy/pull/32848)
[Optional Deprecated:] N/A
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] N/A
