### PR TITLE
Handle deprecated api

### DIFF
--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider.h
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider.h
@@ -70,6 +70,10 @@ private:
   std::vector<std::pair<const Http::LowerCaseString, const std::string>> parsed_headers_to_add_;
   Http::AsyncClient::Request* active_request_{};
   SamplerConfig sampler_config_;
+
+  void handleConfig(
+      const envoy::extensions::tracers::opentelemetry::samplers::v3::DynatraceSamplerConfig&
+          config);
 };
 
 using SamplerConfigProviderPtr = std::unique_ptr<SamplerConfigProvider>;

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/config_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/config_test.cc
@@ -25,6 +25,15 @@ TEST(DynatraceSamplerFactoryTest, Test) {
     name: envoy.tracers.opentelemetry.samplers.dynatrace
     typed_config:
         "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.DynatraceSamplerConfig
+        http_service:
+          http_uri:
+            cluster: "cluster_name"
+            uri: "https://testhost.com/api/v2/samplingConfiguration"
+            timeout: 10s
+          request_headers_to_add:
+          - header:
+              key: "authorization"
+              value: "Api-Token tokenval"
   )EOF";
   TestUtility::loadFromYaml(sampler_yaml, typed_config);
 

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_integration_test.cc
@@ -39,6 +39,15 @@ public:
           "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.samplers.v3.DynatraceSamplerConfig
           tenant: "abc12345"
           cluster_id: -1743916452
+          http_service:
+            http_uri:
+              cluster: "cluster_name"
+              uri: "https://testhost.com/api/v2/samplingConfiguration"
+              timeout: 10s
+            request_headers_to_add:
+            - header:
+                key: "authorization"
+                value: "Api-Token tokenval"
   )EOF";
 
     auto tracing_config =

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/sampler_config_provider_test.cc
@@ -20,7 +20,6 @@ namespace Tracers {
 namespace OpenTelemetry {
 using testing::NiceMock;
 using testing::Return;
-using testing::ReturnRef;
 
 class SamplerConfigProviderTest : public testing::Test {
 public:
@@ -273,7 +272,7 @@ TEST_F(SamplerConfigProviderTest, TestValueZeroConfigured) {
             SamplerConfig::ROOT_SPANS_PER_MINUTE_DEFAULT);
 }
 
-// Test http_service and http_uri and token are set
+// Test handling if http_service and http_uri are set
 TEST(SamplerConfigProviderTestNoParent, TestConfigHandlingServiceAndUriSet) {
   const std::string yaml_string = R"EOF(
           http_service:
@@ -296,6 +295,7 @@ TEST(SamplerConfigProviderTestNoParent, TestConfigHandlingServiceAndUriSet) {
   EXPECT_THROW(SamplerConfigProviderImpl(tracer_factory_context, proto_config), EnvoyException);
 }
 
+// Test handling if http_service and token are set
 TEST(SamplerConfigProviderTestNoParent, TestConfigHandlingServiceAndTokenSet) {
   const std::string yaml_string = R"EOF(
           http_service:
@@ -316,7 +316,7 @@ TEST(SamplerConfigProviderTestNoParent, TestConfigHandlingServiceAndTokenSet) {
   EXPECT_THROW(SamplerConfigProviderImpl(tracer_factory_context, proto_config), EnvoyException);
 }
 
-// Test if http_service is not set but http_uri and token are set
+// Test handling if http_service is not set but http_uri and token are set
 TEST_F(SamplerConfigProviderTest, TestConfigHandlingDeprecatedAreSet) {
   const std::string yaml_string = R"EOF(
           token: "tokenval"


### PR DESCRIPTION
* config verification is done in SamplerConfigProviderImpl.
* if it fails, an Exception is thrown and caught in opentelemetry_tracer_impl.cc
* sampler_ stays null and is not used.
