### PR TITLE
Add trace capture reason extension parsing to Dynatrace tag

### DIFF
--- a/source/extensions/tracers/opentelemetry/otlp_utils.cc
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.cc
@@ -20,30 +20,47 @@ const std::string& OtlpUtils::getOtlpUserAgentHeader() {
 void OtlpUtils::populateAnyValue(opentelemetry::proto::common::v1::AnyValue& value_proto,
                                  const OTelAttribute& attribute_value) {
   switch (attribute_value.index()) {
-  case opentelemetry::common::AttributeType::kTypeBool:
+  case OTelAttributeType::KTypeBool:
     value_proto.set_bool_value(opentelemetry::nostd::get<bool>(attribute_value) ? true : false);
     break;
-  case opentelemetry::common::AttributeType::kTypeInt:
+  case OTelAttributeType::KTypeInt:
     value_proto.set_int_value(opentelemetry::nostd::get<int32_t>(attribute_value));
     break;
-  case opentelemetry::common::AttributeType::kTypeInt64:
+  case OTelAttributeType::KTypeInt64:
     value_proto.set_int_value(opentelemetry::nostd::get<int64_t>(attribute_value));
     break;
-  case opentelemetry::common::AttributeType::kTypeUInt:
+  case OTelAttributeType::KTypeUInt:
     value_proto.set_int_value(opentelemetry::nostd::get<uint32_t>(attribute_value));
     break;
-  case opentelemetry::common::AttributeType::kTypeUInt64:
+  case OTelAttributeType::KTypeUInt64:
     value_proto.set_int_value(opentelemetry::nostd::get<uint64_t>(attribute_value));
     break;
-  case opentelemetry::common::AttributeType::kTypeDouble:
+  case OTelAttributeType::KTypeDouble:
     value_proto.set_double_value(opentelemetry::nostd::get<double>(attribute_value));
     break;
-  case opentelemetry::common::AttributeType::kTypeCString:
-    value_proto.set_string_value(opentelemetry::nostd::get<const char*>(attribute_value));
-    break;
-  case opentelemetry::common::AttributeType::kTypeString: {
-    const auto sv = opentelemetry::nostd::get<opentelemetry::nostd::string_view>(attribute_value);
+  case OTelAttributeType::KTypeString: {
+    const auto sv = opentelemetry::nostd::get<std::string>(attribute_value);
     value_proto.set_string_value(sv.data(), sv.size());
+    break;
+  }
+  case OTelAttributeType::KTypeStringView: {
+    const auto sv = opentelemetry::nostd::get<absl::string_view>(attribute_value);
+    value_proto.set_string_value(sv.data(), sv.size());
+    break;
+  }
+  case OTelAttributeType::KTypeSpanString: {
+    auto array_value = value_proto.mutable_array_value();
+    for (const auto& val : opentelemetry::nostd::get<std::vector<std::string>>(attribute_value)) {
+      array_value->add_values()->set_string_value(val.data(), val.size());
+    }
+    break;
+  }
+  case OTelAttributeType::KTypeSpanStringView: {
+    auto array_value = value_proto.mutable_array_value();
+    for (const auto& val :
+         opentelemetry::nostd::get<std::vector<absl::string_view>>(attribute_value)) {
+      array_value->add_values()->set_string_value(val.data(), val.size());
+    }
     break;
   }
   default:

--- a/source/extensions/tracers/opentelemetry/otlp_utils.cc
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.cc
@@ -12,6 +12,26 @@ namespace Extensions {
 namespace Tracers {
 namespace OpenTelemetry {
 
+enum OTelAttributeType {
+  KTypeBool,
+  KTypeInt,
+  KTypeUInt,
+  KTypeInt64,
+  KTypeDouble,
+  KTypeString,
+  KTypeStringView,
+  KTypeSpanBool,
+  KTypeSpanInt,
+  KTypeSpanUInt,
+  KTypeSpanInt64,
+  KTypeSpanDouble,
+  KTypeSpanString,
+  KTypeSpanStringView,
+  KTypeUInt64,
+  KTypeSpanUInt64,
+  KTypeSpanByte
+};
+
 const std::string& OtlpUtils::getOtlpUserAgentHeader() {
   CONSTRUCT_ON_FIRST_USE(std::string,
                          fmt::format("OTel-OTLP-Exporter-Envoy/{}", Envoy::VersionInfo::version()));

--- a/source/extensions/tracers/opentelemetry/otlp_utils.h
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.h
@@ -23,9 +23,9 @@ namespace OpenTelemetry {
 using OTelSpanKind = ::opentelemetry::proto::trace::v1::Span::SpanKind;
 
 /**
- * @brief Open-telemetry Attribute
+ * @brief Based Open-telemetry OwnedAttributeValue
  * see
- * https://github.com/open-telemetry/opentelemetry-cpp/blob/main/api/include/opentelemetry/common/attribute_value.h
+ * https://github.com/open-telemetry/opentelemetry-cpp/blob/main/sdk/include/opentelemetry/sdk/common/attribute_utils.h
  */
 using OTelAttribute =
     absl::variant<bool, int32_t, uint32_t, int64_t, double, std::string, absl::string_view,
@@ -33,26 +33,6 @@ using OTelAttribute =
                   std::vector<int64_t>, std::vector<double>, std::vector<std::string>,
                   std::vector<absl::string_view>, uint64_t, std::vector<uint64_t>,
                   std::vector<uint8_t>>;
-
-enum OTelAttributeType {
-  KTypeBool,
-  KTypeInt,
-  KTypeUInt,
-  KTypeInt64,
-  KTypeDouble,
-  KTypeString,
-  KTypeStringView,
-  KTypeSpanBool,
-  KTypeSpanInt,
-  KTypeSpanUInt,
-  KTypeSpanInt64,
-  KTypeSpanDouble,
-  KTypeSpanString,
-  KTypeSpanStringView,
-  KTypeUInt64,
-  KTypeSpanUInt64,
-  KTypeSpanByte
-};
 
 /**
  * @brief Container holding Open-telemetry Attributes

--- a/source/extensions/tracers/opentelemetry/otlp_utils.h
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.h
@@ -23,7 +23,7 @@ namespace OpenTelemetry {
 using OTelSpanKind = ::opentelemetry::proto::trace::v1::Span::SpanKind;
 
 /**
- * @brief Based Open-telemetry OwnedAttributeValue
+ * @brief Based on Open-telemetry OwnedAttributeValue
  * see
  * https://github.com/open-telemetry/opentelemetry-cpp/blob/main/sdk/include/opentelemetry/sdk/common/attribute_utils.h
  */

--- a/source/extensions/tracers/opentelemetry/otlp_utils.h
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <map>
 #include <string>
+#include <vector>
 
+#include "absl/strings/string_view.h"
+#include "absl/types/variant.h"
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/proto/common/v1/common.pb.h"
 #include "opentelemetry/proto/trace/v1/trace.pb.h"
@@ -23,7 +27,32 @@ using OTelSpanKind = ::opentelemetry::proto::trace::v1::Span::SpanKind;
  * see
  * https://github.com/open-telemetry/opentelemetry-cpp/blob/main/api/include/opentelemetry/common/attribute_value.h
  */
-using OTelAttribute = ::opentelemetry::common::AttributeValue;
+using OTelAttribute =
+    absl::variant<bool, int32_t, uint32_t, int64_t, double, std::string, absl::string_view,
+                  std::vector<bool>, std::vector<int32_t>, std::vector<uint32_t>,
+                  std::vector<int64_t>, std::vector<double>, std::vector<std::string>,
+                  std::vector<absl::string_view>, uint64_t, std::vector<uint64_t>,
+                  std::vector<uint8_t>>;
+
+enum OTelAttributeType {
+  KTypeBool,
+  KTypeInt,
+  KTypeUInt,
+  KTypeInt64,
+  KTypeDouble,
+  KTypeString,
+  KTypeStringView,
+  KTypeSpanBool,
+  KTypeSpanInt,
+  KTypeSpanUInt,
+  KTypeSpanInt64,
+  KTypeSpanDouble,
+  KTypeSpanString,
+  KTypeSpanStringView,
+  KTypeUInt64,
+  KTypeSpanUInt64,
+  KTypeSpanByte
+};
 
 /**
  * @brief Container holding Open-telemetry Attributes

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/BUILD
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/BUILD
@@ -37,11 +37,13 @@ envoy_cc_library(
         "sampling_controller.h",
         "stream_summary.h",
         "tenant_id.h",
+        "trace_capture_reason.h",
     ],
     deps = [
         "//source/common/config:datasource_lib",
         "//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",
         "//source/extensions/tracers/opentelemetry/samplers:sampler_lib",
+        "@com_google_absl//absl/types:optional",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/tracers/opentelemetry/samplers/v3:pkg_cc_proto",
     ],

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_tag.h
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_tag.h
@@ -24,6 +24,7 @@ namespace OpenTelemetry {
  * - tag[5]: ignored field. 1 if a span is ignored (not sampled), 0 otherwise
  * - tag[6]: sampling exponent
  * - tag[7]: path info
+ * - tag[8]: optional extensions, e.g. trace capture reason
  */
 class DynatraceTag {
 public:
@@ -55,7 +56,7 @@ public:
     }
 
     // Parse optional payload for trace capture reason (id 8h)
-    absl::optional<TraceCaptureReason> tcr_extension = std::nullopt;
+    absl::optional<TraceCaptureReason> tcr_extension = absl::nullopt;
 
     if (tracestate_components.size() > 8) {
       // Extensions start at index 8

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_tag.h
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_tag.h
@@ -3,10 +3,13 @@
 #include <string>
 #include <vector>
 
+#include "source/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason.h"
+
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -24,11 +27,12 @@ namespace OpenTelemetry {
  */
 class DynatraceTag {
 public:
-  static DynatraceTag createInvalid() { return {false, false, 0, 0}; }
+  static DynatraceTag createInvalid() { return {false, false, 0, 0, absl::nullopt}; }
 
   // Creates a tag using the given values.
-  static DynatraceTag create(bool ignored, uint32_t sampling_exponent, uint32_t path_info) {
-    return {true, ignored, sampling_exponent, path_info};
+  static DynatraceTag create(bool ignored, uint32_t sampling_exponent, uint32_t path_info,
+                             absl::optional<TraceCaptureReason> tcr_extension = absl::nullopt) {
+    return {true, ignored, sampling_exponent, path_info, tcr_extension};
   }
 
   // Creates a DynatraceTag from the value in the tracestate
@@ -45,18 +49,41 @@ public:
     bool ignored = tracestate_components[5] == "1";
     uint32_t sampling_exponent;
     uint32_t path_info;
-    if (absl::SimpleAtoi(tracestate_components[6], &sampling_exponent) &&
-        absl::SimpleHexAtoi(tracestate_components[7], &path_info)) {
-      return {true, ignored, sampling_exponent, path_info};
+    if (!(absl::SimpleAtoi(tracestate_components[6], &sampling_exponent) &&
+          absl::SimpleHexAtoi(tracestate_components[7], &path_info))) {
+      return createInvalid();
     }
-    return createInvalid();
+
+    // Parse optional payload for trace capture reason (id 8h)
+    absl::optional<TraceCaptureReason> tcr_extension = std::nullopt;
+
+    if (tracestate_components.size() > 8) {
+      // Extensions start at index 8
+      for (size_t i = 8; i < tracestate_components.size(); ++i) {
+
+        absl::string_view ext = tracestate_components[i];
+
+        if (ext.size() > 2 && ext.substr(0, 2) == "8h") {
+          // Parse hex payload after '8h'
+          absl::string_view hex = absl::string_view(ext.substr(2));
+          TraceCaptureReason tcr = TraceCaptureReason::create(hex);
+          tcr_extension.emplace(std::move(tcr));
+          break;
+        }
+      }
+    }
+    return {true, ignored, sampling_exponent, path_info, tcr_extension};
   }
 
   // Returns a DynatraceTag as string.
   std::string asString() const {
-    std::string ret = absl::StrCat("fw4;0;0;0;0;", ignored_ ? "1" : "0", ";", sampling_exponent_,
-                                   ";", absl::Hex(path_info_));
-    return ret;
+    if (tcr_extension_ && tcr_extension_->isValid()) {
+      return absl::StrCat("fw4;0;0;0;0;", ignored_ ? "1" : "0", ";", sampling_exponent_, ";",
+                          absl::Hex(path_info_), ";8h01", tcr_extension_->bitmaskHex());
+    }
+
+    return absl::StrCat("fw4;0;0;0;0;", ignored_ ? "1" : "0", ";", sampling_exponent_, ";",
+                        absl::Hex(path_info_));
   }
 
   // Returns true if parsing was successful.
@@ -68,15 +95,20 @@ public:
   // Returns the sampling exponent.
   uint32_t getSamplingExponent() const { return sampling_exponent_; };
 
+  // Returns the trace capture reason extension if present.
+  const absl::optional<TraceCaptureReason>& getTcrExtension() const { return tcr_extension_; }
+
 private:
-  DynatraceTag(bool valid, bool ignored, uint32_t sampling_exponent, uint32_t path_info)
+  DynatraceTag(bool valid, bool ignored, uint32_t sampling_exponent, uint32_t path_info,
+               absl::optional<TraceCaptureReason> tcr_extension)
       : valid_(valid), ignored_(ignored), sampling_exponent_(sampling_exponent),
-        path_info_(path_info) {}
+        path_info_(path_info), tcr_extension_(std::move(tcr_extension)) {}
 
   const bool valid_;
   const bool ignored_;
   const uint32_t sampling_exponent_;
   const uint32_t path_info_;
+  const absl::optional<TraceCaptureReason> tcr_extension_;
 };
 
 } // namespace OpenTelemetry

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason.h
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+class TraceCaptureReason {
+
+  using Version = uint8_t;
+  using PayloadBitMask = uint64_t;
+
+  static const size_t MAX_PAYLOAD_SIZE = sizeof(Version) + sizeof(PayloadBitMask);
+  static constexpr absl::string_view kAtm = "atm";
+  static constexpr absl::string_view kFixed = "fixed";
+  static constexpr absl::string_view kCustom = "custom";
+  static constexpr absl::string_view kMainframe = "mainframe";
+  static constexpr absl::string_view kServerless = "serverless";
+  static constexpr absl::string_view kRum = "rum";
+  static constexpr absl::string_view kUnknown = "unknown";
+
+public:
+  enum { InvalidVersion = 0u, Version1 = 1u };
+
+  // Bit mask values
+  enum Reason : PayloadBitMask {
+    Undefined = 0ull,
+    Atm = 1ull << 0,
+    Fixed = 1ull << 1,
+    Custom = 1ull << 2,
+    Mainframe = 1ull << 3,
+    Serverless = 1ull << 4,
+    Rum = 1ull << 5,
+  };
+
+  static TraceCaptureReason createInvalid() { return {false, 0}; }
+
+  static TraceCaptureReason create(PayloadBitMask tcr_bitmask) { return {true, tcr_bitmask}; }
+
+  static TraceCaptureReason create(const absl::string_view& payload_hex) {
+    if (payload_hex.size() < 4) {
+      // At least 1 byte for version and 1 byte for bitmask (2 hex chars each)
+      return createInvalid();
+    }
+
+    // validate the size of the payload
+    size_t payload_bytes = payload_hex.size() / 2;
+    if (payload_bytes <= sizeof(Version) || payload_bytes > MAX_PAYLOAD_SIZE) {
+      return createInvalid();
+    }
+
+    // Parse version (first byte, 2 hex chars)
+    uint32_t version = 0;
+    if (!absl::SimpleHexAtoi(payload_hex.substr(0, 2), &version) ||
+        version != TraceCaptureReason::Version1) {
+      return createInvalid();
+    }
+
+    uint64_t bitmask = 0;
+    if (!absl::SimpleHexAtoi(payload_hex.substr(2), &bitmask)) {
+      return createInvalid();
+    }
+
+    constexpr PayloadBitMask kValidMask = Atm | Fixed | Custom | Mainframe | Serverless | Rum;
+    if ((bitmask & ~kValidMask) != 0) {
+      return createInvalid();
+    }
+    return create(bitmask);
+  }
+
+  // Returns true if parsing was successful.
+  bool isValid() const { return valid_; };
+
+  std::vector<absl::string_view> toSpanAttributeValue() const {
+    std::vector<absl::string_view> result;
+    if (tcr_bitmask_ & Atm) {
+      result.push_back(kAtm);
+    }
+    if (tcr_bitmask_ & Fixed) {
+      result.push_back(kFixed);
+    }
+    if (tcr_bitmask_ & Custom) {
+      result.push_back(kCustom);
+    }
+    if (tcr_bitmask_ & Mainframe) {
+      result.push_back(kMainframe);
+    }
+    if (tcr_bitmask_ & Serverless) {
+      result.push_back(kServerless);
+    }
+    if (tcr_bitmask_ & Rum) {
+      result.push_back(kRum);
+    }
+    if (result.empty()) {
+      result.push_back(kUnknown);
+    }
+    return result;
+  }
+
+  std::string bitmaskHex() const {
+    // shortcut if only the first 8 bits are used, which will be the common case
+    if (tcr_bitmask_ < 0x100) {
+      return absl::StrCat(absl::Hex(static_cast<uint8_t>(tcr_bitmask_), absl::kZeroPad2));
+    }
+    std::string hex;
+    bool started = false;
+    for (int shift = 56; shift >= 0; shift -= 8) {
+      uint8_t b = static_cast<uint8_t>((tcr_bitmask_ >> shift) & 0xFF);
+      if (b != 0 || started || shift == 0) {
+        absl::StrAppend(&hex, absl::Hex(b, absl::kZeroPad2));
+        started = true;
+      }
+    }
+    return hex;
+  }
+
+private:
+  TraceCaptureReason(bool valid, PayloadBitMask tcr_bitmask)
+      : valid_(valid), tcr_bitmask_(tcr_bitmask) {}
+
+  const bool valid_;
+  const PayloadBitMask tcr_bitmask_;
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/BUILD
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/BUILD
@@ -35,6 +35,7 @@ envoy_extension_cc_test(
         "sampling_controller_test.cc",
         "stream_summary_test.cc",
         "tenant_id_test.cc",
+        "trace_capture_reason_test.cc",
     ],
     extension_names = ["envoy.tracers.opentelemetry.samplers.dynatrace"],
     rbe_pool = "6gig",

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_test.cc
@@ -1,9 +1,13 @@
+#include <algorithm>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <tuple>
 
 #include "envoy/extensions/tracers/opentelemetry/samplers/v3/dynatrace_sampler.pb.h"
 
 #include "source/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler.h"
+#include "source/extensions/tracers/opentelemetry/samplers/sampler.h"
 #include "source/extensions/tracers/opentelemetry/span_context.h"
 
 #include "test/mocks/server/tracer_factory_context.h"
@@ -39,15 +43,9 @@ public:
   MOCK_METHOD(const SamplerConfig&, getSamplerConfig, (), (const override));
 };
 
-class DynatraceSamplerTest : public testing::Test {
-
-  const std::string yaml_string_ = R"EOF(
-          tenant: "abc12345"
-          cluster_id: -1743916452
-  )EOF";
-
+class DynatraceSamplerTestBase {
 public:
-  DynatraceSamplerTest() {
+  DynatraceSamplerTestBase() {
     TestUtility::loadFromYaml(yaml_string_, proto_config_);
     auto scf = std::make_unique<NiceMock<MockSamplerConfigProvider>>();
     ON_CALL(*scf, getSamplerConfig()).WillByDefault(testing::ReturnRef(sampler_config_));
@@ -61,6 +59,10 @@ public:
   }
 
 protected:
+  const std::string yaml_string_ = R"EOF(
+          tenant: "abc12345"
+          cluster_id: -1743916452
+  )EOF";
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   NiceMock<Envoy::Server::Configuration::MockTracerFactoryContext> tracer_factory_context_;
   envoy::extensions::tracers::opentelemetry::samplers::v3::DynatraceSamplerConfig proto_config_;
@@ -68,6 +70,8 @@ protected:
   NiceMock<Event::MockTimer>* timer_;
   std::unique_ptr<DynatraceSampler> sampler_;
 };
+
+class DynatraceSamplerTest : public DynatraceSamplerTestBase, public testing::Test {};
 
 // Verify getDescription
 TEST_F(DynatraceSamplerTest, TestGetDescription) {
@@ -80,11 +84,19 @@ TEST_F(DynatraceSamplerTest, TestWithoutParentContext) {
       sampler_->shouldSample(stream_info_, absl::nullopt, trace_id, "operation_name",
                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
-  EXPECT_EQ(sampling_result.attributes->size(), 1);
+  EXPECT_EQ(sampling_result.attributes->size(), 2);
   EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(
                 sampling_result.attributes->find("supportability.atm_sampling_ratio")->second),
             1);
-  EXPECT_STREQ(sampling_result.tracestate.c_str(), "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95");
+
+  auto tcr = sampling_result.attributes->find("trace.capture.reasons");
+  EXPECT_NE(tcr, sampling_result.attributes->end());
+  auto tcr_values = opentelemetry::nostd::get<std::vector<absl::string_view>>(tcr->second);
+  ASSERT_EQ(tcr_values.size(), 1);
+  EXPECT_EQ(tcr_values[0], "atm");
+
+  EXPECT_STREQ(sampling_result.tracestate.c_str(),
+               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101");
   EXPECT_TRUE(sampling_result.isRecording());
   EXPECT_TRUE(sampling_result.isSampled());
 }
@@ -97,13 +109,13 @@ TEST_F(DynatraceSamplerTest, TestWithUnknownParentContext) {
       sampler_->shouldSample(stream_info_, parent_context, trace_id, "operation_name",
                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
-  EXPECT_EQ(sampling_result.attributes->size(), 1);
+  EXPECT_EQ(sampling_result.attributes->size(), 2);
   EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(
                 sampling_result.attributes->find("supportability.atm_sampling_ratio")->second),
             1);
   // Dynatrace tracestate should be prepended
   EXPECT_STREQ(sampling_result.tracestate.c_str(),
-               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95,some_vendor=some_value");
+               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101,some_vendor=some_value");
   EXPECT_TRUE(sampling_result.isRecording());
   EXPECT_TRUE(sampling_result.isSampled());
 }
@@ -137,7 +149,7 @@ TEST_F(DynatraceSamplerTest, TestWithInvalidDynatraceParentContext) {
                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
   EXPECT_STREQ(sampling_result.tracestate.c_str(),
-               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95,5b3f9fed-980df25c@dt=fw4;4");
+               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101,5b3f9fed-980df25c@dt=fw4;4");
   EXPECT_TRUE(sampling_result.isRecording());
   EXPECT_TRUE(sampling_result.isSampled());
 }
@@ -152,9 +164,9 @@ TEST_F(DynatraceSamplerTest, TestWithInvalidDynatraceParentContext1) {
       sampler_->shouldSample(stream_info_, parent_context, trace_id, "operation_name",
                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
-  EXPECT_STREQ(
-      sampling_result.tracestate.c_str(),
-      "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95,5b3f9fed-980df25c@dt=fw4;4;4af38366;0;0;0;X;123");
+  EXPECT_STREQ(sampling_result.tracestate.c_str(),
+               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101,5b3f9fed-980df25c@dt=fw4;4;4af38366;"
+               "0;0;0;X;123");
   EXPECT_TRUE(sampling_result.isRecording());
   EXPECT_TRUE(sampling_result.isSampled());
 }
@@ -172,7 +184,8 @@ TEST_F(DynatraceSamplerTest, TestWithDynatraceParentContextOtherVersion) {
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
   EXPECT_STREQ(
       sampling_result.tracestate.c_str(),
-      "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95,5b3f9fed-980df25c@dt=fw3;4;4af38366;0;0;0;0;123;"
+      "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101,5b3f9fed-980df25c@dt=fw3;4;4af38366;0;0;0;0;"
+      "123;"
       "8eae;2h01;3h4af38366;4h00;5h01;6h67a9a23155e1741b5b35368e08e6ece5;7h9d83def9a4939b7b");
   EXPECT_TRUE(sampling_result.isRecording());
   EXPECT_TRUE(sampling_result.isSampled());
@@ -211,13 +224,14 @@ TEST_F(DynatraceSamplerTest, TestWithDynatraceParentContextFromDifferentTenant) 
                              ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
   // sampling decision on tracestate should be ignored because it is from a different tenant.
   EXPECT_EQ(sampling_result.decision, Decision::RecordAndSample);
-  EXPECT_EQ(sampling_result.attributes->size(), 1);
+  EXPECT_EQ(sampling_result.attributes->size(), 2);
   EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(
                 sampling_result.attributes->find("supportability.atm_sampling_ratio")->second),
             1);
   // new Dynatrace tag should be prepended, already existing tag should be kept
   const char* exptected =
-      "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95,6666ad40-980df25c@dt=fw4;4;4af38366;0;0;1;2;123;"
+      "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101,6666ad40-980df25c@dt=fw4;4;4af38366;0;0;1;2;"
+      "123;"
       "8eae;2h01;3h4af38366;4h00;5h01;6h67a9a23155e1741b5b35368e08e6ece5;7h9d83def9a4939b7b";
   EXPECT_STREQ(sampling_result.tracestate.c_str(), exptected);
   EXPECT_TRUE(sampling_result.isRecording());
@@ -338,6 +352,83 @@ TEST_F(DynatraceSamplerTest, TestSampling) {
   }
 }
 
+struct SamplingResultTestData {
+  std::vector<std::string> tcr_values;
+  std::string tracestate;
+
+  SamplingResultTestData(std::vector<std::string> tcr, std::string t)
+      : tcr_values(std::move(tcr)), tracestate(std::move(t)) {}
+};
+
+class DynatraceSamplerTraceCaptureReasonTest
+    : public DynatraceSamplerTestBase,
+      public ::testing::TestWithParam<std::tuple<std::string, SamplingResultTestData>> {};
+
+// Verify sampler behavior depending on which trace capture reason was received
+TEST_P(DynatraceSamplerTraceCaptureReasonTest, TraceCaptureReasonScenarios) {
+  std::string incomingTraceState = std::get<0>(GetParam());
+  SamplingResultTestData expected = std::get<1>(GetParam());
+
+  SpanContext parent_context("00", trace_id, parent_span_id, true, incomingTraceState);
+
+  auto actual =
+      sampler_->shouldSample(stream_info_, parent_context, trace_id, "operation_name",
+                             ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_SERVER, {}, {});
+
+  // Check that the sampling result contains the expected trace capture reason attributes
+  if (!expected.tcr_values.empty()) {
+    auto actual_tcr_values = opentelemetry::nostd::get<std::vector<absl::string_view>>(
+        actual.attributes->find("trace.capture.reasons")->second);
+    ASSERT_EQ(actual_tcr_values.size(), expected.tcr_values.size());
+
+    std::vector<std::string> actual_sorted;
+    actual_sorted.reserve(actual_tcr_values.size());
+    for (const auto& v : actual_tcr_values) {
+      actual_sorted.push_back(std::string(v));
+    }
+
+    std::sort(actual_sorted.begin(), actual_sorted.end());
+    std::sort(expected.tcr_values.begin(), expected.tcr_values.end());
+    EXPECT_EQ(actual_sorted, expected.tcr_values);
+  } else {
+    // verify that there's no trace.capture.reasons attribute in the map
+    EXPECT_EQ(actual.attributes->find("trace.capture.reasons"), actual.attributes->end());
+  }
+
+  EXPECT_STREQ(actual.tracestate.c_str(), expected.tracestate.c_str());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TraceCaptureReasonTestCase, DynatraceSamplerTraceCaptureReasonTest,
+    // tracestate with Dynatrace tag but no trace capture reason extension
+    ::testing::Values(
+        // No trace capture reason present in the tracestate
+        std::make_tuple(
+            "5b3f9fed-980df25c@dt=fw4;4;4af38366;0;0;1;2;123;8eae;2h01;3h4af38366;4h00;5h01;",
+            SamplingResultTestData(
+                {},
+                "5b3f9fed-980df25c@dt=fw4;4;4af38366;0;0;1;2;123;8eae;2h01;3h4af38366;4h00;5h01;")),
+
+        // Valid trace capture reason present in the tracestate
+        std::make_tuple("5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101",
+                        SamplingResultTestData({"atm"},
+                                               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101")),
+
+        // trace capture reason present in the tracestate with an unsupported version
+        std::make_tuple("5b3f9fed-980df25c@dt=fw3;0;0;0;0;0;0;95;8h0101",
+                        SamplingResultTestData({"atm"},
+                                               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101,"
+                                               "5b3f9fed-980df25c@dt=fw3;0;0;0;0;0;0;95;8h0101")),
+
+        // Multiple, valid trace capture reasons present in the tracestate
+        std::make_tuple("5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0107",
+                        SamplingResultTestData({"atm", "fixed", "custom"},
+                                               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0107")),
+
+        // Root trace started by Envoy - sampler should use the correct reason
+        std::make_tuple("",
+                        SamplingResultTestData({"atm"},
+                                               "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;95;8h0101"))));
 } // namespace OpenTelemetry
 } // namespace Tracers
 } // namespace Extensions

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_test.cc
@@ -90,7 +90,7 @@ TEST_F(DynatraceSamplerTest, TestWithoutParentContext) {
             1);
 
   auto tcr = sampling_result.attributes->find("trace.capture.reasons");
-  EXPECT_NE(tcr, sampling_result.attributes->end());
+  ASSERT_NE(tcr, sampling_result.attributes->end());
   auto tcr_values = opentelemetry::nostd::get<std::vector<absl::string_view>>(tcr->second);
   ASSERT_EQ(tcr_values.size(), 1);
   EXPECT_EQ(tcr_values[0], "atm");

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason_test.cc
@@ -1,0 +1,90 @@
+#include "source/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+class TraceCaptureReasonTest : public ::testing::Test {};
+
+TEST_F(TraceCaptureReasonTest, ParseSingleReasonATM) {
+  auto tcr = TraceCaptureReason::create("0101");
+  EXPECT_TRUE(tcr.isValid());
+  EXPECT_EQ(tcr.bitmaskHex(), "01");
+  auto reasons = tcr.toSpanAttributeValue();
+  ASSERT_EQ(reasons.size(), 1);
+  EXPECT_EQ(reasons[0], "atm");
+}
+
+TEST_F(TraceCaptureReasonTest, ParseSingleReasonFixed) {
+  auto tcr = TraceCaptureReason::create("0102");
+  EXPECT_TRUE(tcr.isValid());
+  EXPECT_EQ(tcr.bitmaskHex(), "02");
+  auto reasons = tcr.toSpanAttributeValue();
+  ASSERT_EQ(reasons.size(), 1);
+  EXPECT_EQ(reasons[0], "fixed");
+}
+
+TEST_F(TraceCaptureReasonTest, ParseMultipleReasonsATMFixed) {
+  auto tcr = TraceCaptureReason::create("0103"); // ATM + Fixed
+  EXPECT_TRUE(tcr.isValid());
+  EXPECT_EQ(tcr.bitmaskHex(), "03");
+  auto reasons = tcr.toSpanAttributeValue();
+  ASSERT_EQ(reasons.size(), 2);
+  EXPECT_EQ(reasons[0], "atm");
+  EXPECT_EQ(reasons[1], "fixed");
+}
+
+TEST_F(TraceCaptureReasonTest, ParseMultipleReasonsAll) {
+  auto tcr = TraceCaptureReason::create("0107"); // ATM + Fixed + Custom
+  EXPECT_TRUE(tcr.isValid());
+  EXPECT_EQ(tcr.bitmaskHex(), "07");
+  auto reasons = tcr.toSpanAttributeValue();
+  ASSERT_EQ(reasons.size(), 3);
+  EXPECT_EQ(reasons[0], "atm");
+  EXPECT_EQ(reasons[1], "fixed");
+  EXPECT_EQ(reasons[2], "custom");
+}
+
+TEST_F(TraceCaptureReasonTest, ParseReasonRum) {
+  auto tcr = TraceCaptureReason::create("0120"); // Rum only
+  EXPECT_TRUE(tcr.isValid());
+  EXPECT_EQ(tcr.bitmaskHex(), "20");
+  auto reasons = tcr.toSpanAttributeValue();
+  ASSERT_EQ(reasons.size(), 1);
+  EXPECT_EQ(reasons[0], "rum");
+}
+
+TEST_F(TraceCaptureReasonTest, ParseMultipleReasonsATMCustomRum) {
+  auto tcr = TraceCaptureReason::create("0135"); // ATM + Custom + Rum
+  EXPECT_TRUE(tcr.isValid());
+  EXPECT_EQ(tcr.bitmaskHex(), "35");
+  auto reasons = tcr.toSpanAttributeValue();
+  ASSERT_EQ(reasons.size(), 3);
+  EXPECT_EQ(reasons[0], "atm");
+  EXPECT_EQ(reasons[1], "custom");
+  EXPECT_EQ(reasons[2], "rum");
+}
+
+TEST_F(TraceCaptureReasonTest, InvalidVersion) {
+  auto tcr = TraceCaptureReason::create("0201"); // version 2 not supported
+  EXPECT_FALSE(tcr.isValid());
+}
+
+TEST_F(TraceCaptureReasonTest, InvalidBitmask) {
+  auto tcr = TraceCaptureReason::create("01FF"); // FF includes undefined bits
+  EXPECT_FALSE(tcr.isValid());
+}
+
+TEST_F(TraceCaptureReasonTest, InvalidShortPayload) {
+  auto tcr = TraceCaptureReason::create("01"); // too short
+  EXPECT_FALSE(tcr.isValid());
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason_test.cc
@@ -59,9 +59,9 @@ TEST_F(TraceCaptureReasonTest, ParseReasonRum) {
 }
 
 TEST_F(TraceCaptureReasonTest, ParseMultipleReasonsATMCustomRum) {
-  auto tcr = TraceCaptureReason::create("0135"); // ATM + Custom + Rum
+  auto tcr = TraceCaptureReason::create("0125"); // ATM + Custom + Rum
   EXPECT_TRUE(tcr.isValid());
-  EXPECT_EQ(tcr.bitmaskHex(), "35");
+  EXPECT_EQ(tcr.bitmaskHex(), "25");
   auto reasons = tcr.toSpanAttributeValue();
   ASSERT_EQ(reasons.size(), 3);
   EXPECT_EQ(reasons[0], "atm");
@@ -81,6 +81,16 @@ TEST_F(TraceCaptureReasonTest, InvalidBitmask) {
 
 TEST_F(TraceCaptureReasonTest, InvalidShortPayload) {
   auto tcr = TraceCaptureReason::create("01"); // too short
+  EXPECT_FALSE(tcr.isValid());
+}
+
+TEST_F(TraceCaptureReasonTest, InvalidOddLengthPayload010) {
+  auto tcr = TraceCaptureReason::create("010"); // odd number of chars
+  EXPECT_FALSE(tcr.isValid());
+}
+
+TEST_F(TraceCaptureReasonTest, InvalidOddLengthPayload01010) {
+  auto tcr = TraceCaptureReason::create("01010"); // odd number of chars
   EXPECT_FALSE(tcr.isValid());
 }
 


### PR DESCRIPTION
Internal PR for adding the trace capture reason to the Dynatrace sampler in Envoy. 
